### PR TITLE
meta: Ignore vite config in `.eslintrc`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,14 +1,15 @@
 /* eslint-env node */
-require('@rushstack/eslint-patch/modern-module-resolution')
+require('@rushstack/eslint-patch/modern-module-resolution');
 
 module.exports = {
   root: true,
-  'extends': [
+  extends: [
     'plugin:vue/vue3-essential',
     'eslint:recommended',
-    '@vue/eslint-config-prettier'
+    '@vue/eslint-config-prettier',
   ],
+  ignorePatterns: ['vite.config.js'],
   parserOptions: {
-    ecmaVersion: 'latest'
-  }
-}
+    ecmaVersion: 'latest',
+  },
+};


### PR DESCRIPTION
Stuff like `process` is not defined - I would just ignore this file with eslint since it's not really part of the project.