### PR TITLE
meta(frontend): Enable `@sentry/vite-plugin` experiments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "gib-potato",
       "dependencies": {
-        "@sentry/vite-plugin": "^0.4.0",
+        "@sentry/vite-plugin": "^0.5.0",
         "@sentry/vue": "^7.44.1",
         "axios": "^1.3.4",
         "vue": "^3.2.47",
@@ -555,13 +555,15 @@
       }
     },
     "node_modules/@sentry/bundler-plugin-core": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-0.4.0.tgz",
-      "integrity": "sha512-Xi+dqaSOoxbdmxegX7f66FVOxm2dVJLmrMXUpoNyuV6ASoccRWzouGaFekP059SUTTD05ytk1mHqwgVuBCA0Dw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-0.5.0.tgz",
+      "integrity": "sha512-vj0UlbcdjoRUF3XNXQLKvwJzb8+kZ0TT/J7kknhak2ZyDy2zrHs83CUmCLRHthEQwKFI1n7J2JSLHRU1xN+XHQ==",
       "dependencies": {
-        "@sentry/cli": "^2.10.0",
+        "@sentry/cli": "^2.17.0",
         "@sentry/node": "^7.19.0",
         "@sentry/tracing": "^7.19.0",
+        "find-up": "5.0.0",
+        "glob": "9.3.2",
         "magic-string": "0.27.0",
         "unplugin": "1.0.1"
       },
@@ -569,10 +571,49 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/glob": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.2.tgz",
+      "integrity": "sha512-BTv/JhKXFEHsErMte/AnfiSv8yYOLLiyH2lTg8vn02O21zWFgHPTfxtgn1QRe7NRgggUhC8hacR2Re94svHqeA==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^7.4.1",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/minimatch": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.5.tgz",
+      "integrity": "sha512-OzOamaOmNBJZUv2qqY1OSWa+++4YPpOkLgkc0w30Oov5ufKlWWXnFUl0l4dgmSv5Shq/zRVkEOXAe2NaqO4l5Q==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@sentry/cli": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.16.1.tgz",
-      "integrity": "sha512-OrrRr4nGtivjc/ZEt/BLzJcivkBM91QQiumU5gWooMNYZJhVDpsDsxQniuJVec1zpQRcC3qpTuH5cAkMgiO2Tw==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.17.0.tgz",
+      "integrity": "sha512-CHIMEg8+YNCpEBDgUctu+DvG3S8+g8Zn9jTE5MMGINNmGkQTMG179LuDE04B/inaCYixLVNpFPTe6Iow3tXjnQ==",
       "hasInstallScript": true,
       "dependencies": {
         "https-proxy-agent": "^5.0.0",
@@ -602,17 +643,64 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "7.46.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.46.0.tgz",
-      "integrity": "sha512-+GrgJMCye2WXGarRiU5IJHCK27xg7xbPc2XjGojBKbBoZfqxVAWbXEK4bnBQgRGP1pCmrU/M6ZhVgR3dP580xA==",
+      "version": "7.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.47.0.tgz",
+      "integrity": "sha512-LTg2r5EV9yh4GLYDF+ViSltR9LLj/pcvk8YhANJcMO3Fp//xh8njcdU0FC2yNthUREawYDzAsVzLyCYJfV0H1A==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.46.0",
-        "@sentry/core": "7.46.0",
-        "@sentry/types": "7.46.0",
-        "@sentry/utils": "7.46.0",
+        "@sentry-internal/tracing": "7.47.0",
+        "@sentry/core": "7.47.0",
+        "@sentry/types": "7.47.0",
+        "@sentry/utils": "7.47.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry-internal/tracing": {
+      "version": "7.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.47.0.tgz",
+      "integrity": "sha512-udpHnCzF8DQsWf0gQwd0XFGp6Y8MOiwnl8vGt2ohqZGS3m1+IxoRLXsSkD8qmvN6KKDnwbaAvYnK0z0L+AW95g==",
+      "dependencies": {
+        "@sentry/core": "7.47.0",
+        "@sentry/types": "7.47.0",
+        "@sentry/utils": "7.47.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry/core": {
+      "version": "7.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.47.0.tgz",
+      "integrity": "sha512-EFhZhKdMu7wKmWYZwbgTi8FNZ7Fq+HdlXiZWNz51Bqe3pHmfAkdHtAEs0Buo0v623MKA0CA4EjXIazGUM34XTg==",
+      "dependencies": {
+        "@sentry/types": "7.47.0",
+        "@sentry/utils": "7.47.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry/types": {
+      "version": "7.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.47.0.tgz",
+      "integrity": "sha512-GxXocplN0j1+uczovHrfkykl9wvkamDtWxlPUQgyGlbLGZn+UH1Y79D4D58COaFWGEZdSNKr62gZAjfEYu9nQA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry/utils": {
+      "version": "7.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.47.0.tgz",
+      "integrity": "sha512-A89SaOLp6XeZfByeYo2C8Ecye/YAtk/gENuyOUhQEdMulI6mZdjqtHAp7pTMVgkBc/YNARVuoa+kR/IdRrTPkQ==",
+      "dependencies": {
+        "@sentry/types": "7.47.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -633,11 +721,58 @@
       }
     },
     "node_modules/@sentry/tracing": {
-      "version": "7.46.0",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.46.0.tgz",
-      "integrity": "sha512-7qBtzmu7CDHclSKp+ZRrxoDcMyrev6/rxD2rSVJgB3o8gd2XGcO5vx9vuUOoYF0xTfOMXscR6Ft6JXE49xovYg==",
+      "version": "7.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.47.0.tgz",
+      "integrity": "sha512-hJCpKdekwaFNbCVXxfCz5IxfSEJIKnkPmRSVHITOm5VhKwq2e5kmy4Rn6bzSETwJFSDE8LGbR/3eSfGTqw37XA==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.46.0"
+        "@sentry-internal/tracing": "7.47.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/tracing/node_modules/@sentry-internal/tracing": {
+      "version": "7.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.47.0.tgz",
+      "integrity": "sha512-udpHnCzF8DQsWf0gQwd0XFGp6Y8MOiwnl8vGt2ohqZGS3m1+IxoRLXsSkD8qmvN6KKDnwbaAvYnK0z0L+AW95g==",
+      "dependencies": {
+        "@sentry/core": "7.47.0",
+        "@sentry/types": "7.47.0",
+        "@sentry/utils": "7.47.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/tracing/node_modules/@sentry/core": {
+      "version": "7.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.47.0.tgz",
+      "integrity": "sha512-EFhZhKdMu7wKmWYZwbgTi8FNZ7Fq+HdlXiZWNz51Bqe3pHmfAkdHtAEs0Buo0v623MKA0CA4EjXIazGUM34XTg==",
+      "dependencies": {
+        "@sentry/types": "7.47.0",
+        "@sentry/utils": "7.47.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/tracing/node_modules/@sentry/types": {
+      "version": "7.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.47.0.tgz",
+      "integrity": "sha512-GxXocplN0j1+uczovHrfkykl9wvkamDtWxlPUQgyGlbLGZn+UH1Y79D4D58COaFWGEZdSNKr62gZAjfEYu9nQA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/tracing/node_modules/@sentry/utils": {
+      "version": "7.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.47.0.tgz",
+      "integrity": "sha512-A89SaOLp6XeZfByeYo2C8Ecye/YAtk/gENuyOUhQEdMulI6mZdjqtHAp7pTMVgkBc/YNARVuoa+kR/IdRrTPkQ==",
+      "dependencies": {
+        "@sentry/types": "7.47.0",
+        "tslib": "^1.9.3"
       },
       "engines": {
         "node": ">=8"
@@ -664,11 +799,11 @@
       }
     },
     "node_modules/@sentry/vite-plugin": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-0.4.0.tgz",
-      "integrity": "sha512-dBxM00MCLzO/idzAqj33ZfbIBKZxP+FzpxtS2WaV0yzad9yLBAFZ/VGDIGHQJC0Qo3fsFi/CZpmN39wJkJoWFA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-0.5.0.tgz",
+      "integrity": "sha512-IYl3KopagmIv7pqwryZnHlZX0wdACp4LVxQJQNcmVSswRDRBHhZR4tHwmBsp2CMgnHD+tLK3ukBVsw512SxSQA==",
       "dependencies": {
-        "@sentry/bundler-plugin-core": "0.4.0"
+        "@sentry/bundler-plugin-core": "0.5.0"
       },
       "engines": {
         "node": ">= 10"
@@ -994,8 +1129,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -1640,7 +1774,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -1719,8 +1852,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -2016,7 +2148,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -2118,6 +2249,14 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.5.tgz",
+      "integrity": "sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ms": {
@@ -2261,7 +2400,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -2276,7 +2414,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -2303,7 +2440,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2331,6 +2467,29 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/path-scurry": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.6.3.tgz",
+      "integrity": "sha512-RAmB+n30SlN+HnNx6EbcpoDy9nwdpcGPnEKrJnu6GZoDWBdIjo1UQMVtW2ybtC7LC2oKLcMq8y5g8WnKLiod9g==",
+      "dependencies": {
+        "lru-cache": "^7.14.1",
+        "minipass": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -3205,7 +3364,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -3497,21 +3655,52 @@
       }
     },
     "@sentry/bundler-plugin-core": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-0.4.0.tgz",
-      "integrity": "sha512-Xi+dqaSOoxbdmxegX7f66FVOxm2dVJLmrMXUpoNyuV6ASoccRWzouGaFekP059SUTTD05ytk1mHqwgVuBCA0Dw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-0.5.0.tgz",
+      "integrity": "sha512-vj0UlbcdjoRUF3XNXQLKvwJzb8+kZ0TT/J7kknhak2ZyDy2zrHs83CUmCLRHthEQwKFI1n7J2JSLHRU1xN+XHQ==",
       "requires": {
-        "@sentry/cli": "^2.10.0",
+        "@sentry/cli": "^2.17.0",
         "@sentry/node": "^7.19.0",
         "@sentry/tracing": "^7.19.0",
+        "find-up": "5.0.0",
+        "glob": "9.3.2",
         "magic-string": "0.27.0",
         "unplugin": "1.0.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "9.3.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.2.tgz",
+          "integrity": "sha512-BTv/JhKXFEHsErMte/AnfiSv8yYOLLiyH2lTg8vn02O21zWFgHPTfxtgn1QRe7NRgggUhC8hacR2Re94svHqeA==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "minimatch": "^7.4.1",
+            "minipass": "^4.2.4",
+            "path-scurry": "^1.6.1"
+          }
+        },
+        "minimatch": {
+          "version": "7.4.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.5.tgz",
+          "integrity": "sha512-OzOamaOmNBJZUv2qqY1OSWa+++4YPpOkLgkc0w30Oov5ufKlWWXnFUl0l4dgmSv5Shq/zRVkEOXAe2NaqO4l5Q==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "@sentry/cli": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.16.1.tgz",
-      "integrity": "sha512-OrrRr4nGtivjc/ZEt/BLzJcivkBM91QQiumU5gWooMNYZJhVDpsDsxQniuJVec1zpQRcC3qpTuH5cAkMgiO2Tw==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.17.0.tgz",
+      "integrity": "sha512-CHIMEg8+YNCpEBDgUctu+DvG3S8+g8Zn9jTE5MMGINNmGkQTMG179LuDE04B/inaCYixLVNpFPTe6Iow3tXjnQ==",
       "requires": {
         "https-proxy-agent": "^5.0.0",
         "node-fetch": "^2.6.7",
@@ -3531,18 +3720,55 @@
       }
     },
     "@sentry/node": {
-      "version": "7.46.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.46.0.tgz",
-      "integrity": "sha512-+GrgJMCye2WXGarRiU5IJHCK27xg7xbPc2XjGojBKbBoZfqxVAWbXEK4bnBQgRGP1pCmrU/M6ZhVgR3dP580xA==",
+      "version": "7.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.47.0.tgz",
+      "integrity": "sha512-LTg2r5EV9yh4GLYDF+ViSltR9LLj/pcvk8YhANJcMO3Fp//xh8njcdU0FC2yNthUREawYDzAsVzLyCYJfV0H1A==",
       "requires": {
-        "@sentry-internal/tracing": "7.46.0",
-        "@sentry/core": "7.46.0",
-        "@sentry/types": "7.46.0",
-        "@sentry/utils": "7.46.0",
+        "@sentry-internal/tracing": "7.47.0",
+        "@sentry/core": "7.47.0",
+        "@sentry/types": "7.47.0",
+        "@sentry/utils": "7.47.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry-internal/tracing": {
+          "version": "7.47.0",
+          "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.47.0.tgz",
+          "integrity": "sha512-udpHnCzF8DQsWf0gQwd0XFGp6Y8MOiwnl8vGt2ohqZGS3m1+IxoRLXsSkD8qmvN6KKDnwbaAvYnK0z0L+AW95g==",
+          "requires": {
+            "@sentry/core": "7.47.0",
+            "@sentry/types": "7.47.0",
+            "@sentry/utils": "7.47.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/core": {
+          "version": "7.47.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.47.0.tgz",
+          "integrity": "sha512-EFhZhKdMu7wKmWYZwbgTi8FNZ7Fq+HdlXiZWNz51Bqe3pHmfAkdHtAEs0Buo0v623MKA0CA4EjXIazGUM34XTg==",
+          "requires": {
+            "@sentry/types": "7.47.0",
+            "@sentry/utils": "7.47.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/types": {
+          "version": "7.47.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.47.0.tgz",
+          "integrity": "sha512-GxXocplN0j1+uczovHrfkykl9wvkamDtWxlPUQgyGlbLGZn+UH1Y79D4D58COaFWGEZdSNKr62gZAjfEYu9nQA=="
+        },
+        "@sentry/utils": {
+          "version": "7.47.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.47.0.tgz",
+          "integrity": "sha512-A89SaOLp6XeZfByeYo2C8Ecye/YAtk/gENuyOUhQEdMulI6mZdjqtHAp7pTMVgkBc/YNARVuoa+kR/IdRrTPkQ==",
+          "requires": {
+            "@sentry/types": "7.47.0",
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "@sentry/replay": {
@@ -3556,11 +3782,48 @@
       }
     },
     "@sentry/tracing": {
-      "version": "7.46.0",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.46.0.tgz",
-      "integrity": "sha512-7qBtzmu7CDHclSKp+ZRrxoDcMyrev6/rxD2rSVJgB3o8gd2XGcO5vx9vuUOoYF0xTfOMXscR6Ft6JXE49xovYg==",
+      "version": "7.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.47.0.tgz",
+      "integrity": "sha512-hJCpKdekwaFNbCVXxfCz5IxfSEJIKnkPmRSVHITOm5VhKwq2e5kmy4Rn6bzSETwJFSDE8LGbR/3eSfGTqw37XA==",
       "requires": {
-        "@sentry-internal/tracing": "7.46.0"
+        "@sentry-internal/tracing": "7.47.0"
+      },
+      "dependencies": {
+        "@sentry-internal/tracing": {
+          "version": "7.47.0",
+          "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.47.0.tgz",
+          "integrity": "sha512-udpHnCzF8DQsWf0gQwd0XFGp6Y8MOiwnl8vGt2ohqZGS3m1+IxoRLXsSkD8qmvN6KKDnwbaAvYnK0z0L+AW95g==",
+          "requires": {
+            "@sentry/core": "7.47.0",
+            "@sentry/types": "7.47.0",
+            "@sentry/utils": "7.47.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/core": {
+          "version": "7.47.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.47.0.tgz",
+          "integrity": "sha512-EFhZhKdMu7wKmWYZwbgTi8FNZ7Fq+HdlXiZWNz51Bqe3pHmfAkdHtAEs0Buo0v623MKA0CA4EjXIazGUM34XTg==",
+          "requires": {
+            "@sentry/types": "7.47.0",
+            "@sentry/utils": "7.47.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/types": {
+          "version": "7.47.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.47.0.tgz",
+          "integrity": "sha512-GxXocplN0j1+uczovHrfkykl9wvkamDtWxlPUQgyGlbLGZn+UH1Y79D4D58COaFWGEZdSNKr62gZAjfEYu9nQA=="
+        },
+        "@sentry/utils": {
+          "version": "7.47.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.47.0.tgz",
+          "integrity": "sha512-A89SaOLp6XeZfByeYo2C8Ecye/YAtk/gENuyOUhQEdMulI6mZdjqtHAp7pTMVgkBc/YNARVuoa+kR/IdRrTPkQ==",
+          "requires": {
+            "@sentry/types": "7.47.0",
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "@sentry/types": {
@@ -3578,11 +3841,11 @@
       }
     },
     "@sentry/vite-plugin": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-0.4.0.tgz",
-      "integrity": "sha512-dBxM00MCLzO/idzAqj33ZfbIBKZxP+FzpxtS2WaV0yzad9yLBAFZ/VGDIGHQJC0Qo3fsFi/CZpmN39wJkJoWFA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-0.5.0.tgz",
+      "integrity": "sha512-IYl3KopagmIv7pqwryZnHlZX0wdACp4LVxQJQNcmVSswRDRBHhZR4tHwmBsp2CMgnHD+tLK3ukBVsw512SxSQA==",
       "requires": {
-        "@sentry/bundler-plugin-core": "0.4.0"
+        "@sentry/bundler-plugin-core": "0.5.0"
       }
     },
     "@sentry/vue": {
@@ -3844,8 +4107,7 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -4310,7 +4572,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
       "requires": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -4356,8 +4617,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "fsevents": {
       "version": "2.3.2",
@@ -4576,7 +4836,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
       "requires": {
         "p-locate": "^5.0.0"
       }
@@ -4652,6 +4911,11 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "minipass": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.5.tgz",
+      "integrity": "sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q=="
     },
     "ms": {
       "version": "2.1.2",
@@ -4753,7 +5017,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "requires": {
         "yocto-queue": "^0.1.0"
       }
@@ -4762,7 +5025,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
       "requires": {
         "p-limit": "^3.0.2"
       }
@@ -4779,8 +5041,7 @@
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -4799,6 +5060,22 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "path-scurry": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.6.3.tgz",
+      "integrity": "sha512-RAmB+n30SlN+HnNx6EbcpoDy9nwdpcGPnEKrJnu6GZoDWBdIjo1UQMVtW2ybtC7LC2oKLcMq8y5g8WnKLiod9g==",
+      "requires": {
+        "lru-cache": "^7.14.1",
+        "minipass": "^4.0.2"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "7.18.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+          "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
+        }
+      }
     },
     "picocolors": {
       "version": "1.0.0",
@@ -5354,8 +5631,7 @@
     "yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@sentry/vite-plugin": "^0.4.0",
+    "@sentry/vite-plugin": "^0.5.0",
     "@sentry/vue": "^7.44.1",
     "axios": "^1.3.4",
     "vue": "^3.2.47",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,25 +1,29 @@
-import { fileURLToPath, URL } from 'node:url'
+// @ts-check
+import { fileURLToPath, URL } from 'node:url';
 
-import { defineConfig } from 'vite'
-import vue from '@vitejs/plugin-vue'
-import { sentryVitePlugin } from '@sentry/vite-plugin'
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import { sentryVitePlugin } from '@sentry/vite-plugin';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
     vue(),
     sentryVitePlugin({
-      include: './webroot/assets',
+      include: [], // we're using debug ID upload instead (see _experiments.debugIdUpload)
       org: process.env.SENTRY_ORG,
       project: process.env.SENTRY_PROJECT,
       authToken: process.env.SENTRY_AUTH_TOKEN,
       dryRun: !process.env.SENTRY_AUTH_TOKEN,
-      cleanArtifacts: true,
-      stripCommonPrefix: true,
-      rewrite: true,
       setCommits: {
         auto: true,
         ignoreEmpty: true,
+      },
+      _experiments: {
+        injectBuildInformation: true,
+        debugIdUpload: {
+          include: './webroot/assets/**',
+        },
       },
     }),
   ],
@@ -30,13 +34,13 @@ export default defineConfig({
     manifest: true,
     minify: 'esbuild',
     rollupOptions: {
-      input: './frontend/src/main.js'
+      input: './frontend/src/main.js',
     },
   },
   envDir: './frontend/config',
   resolve: {
     alias: {
-      '@': fileURLToPath(new URL('./frontend/src', import.meta.url))
+      '@': fileURLToPath(new URL('./frontend/src', import.meta.url)),
     },
   },
-})
+});


### PR DESCRIPTION
- Bumps `@sentry/vite-plugin` to the newest version
- Enables the `injectBuildInformation` experiment which should inject some build information into events
- Enables the `debugIdUpload` experiment which switches us to the 'new' way of uploading source maps and source files