### PR TITLE
ref(backend): Remove duplicated session.cookie_domain config

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -417,8 +417,6 @@ return [
         'defaults' => 'database',
         'timeout' => 60 * 24 * 14, // 2 weeks
         'ini' => [
-            // @FIXME Make this depending on env
-            'session.cookie_domain' => 'gipotato.eu.ngrok.io',
             'session.gc_maxlifetime' => 60 * 60 * 24 * 14, // 2 weeks
             'session.cookie_lifetime' => 60 * 60 * 24 * 14,
             'session.cookie_domain' => env('MAIN_DOMAIN'),


### PR DESCRIPTION
`session.cookie_domain` was set multiple times.