### PR TITLE
feat: Developer setup without php on host machine

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,12 @@
+export SECURITY_SALT=development
+export PATH="$PWD/bin/:$PATH"
+
+if [ ! -d vendor ]; then
+    echo "no vendor/ directory found, installing dependencies"
+    composer install -n
+    echo
+    echo
+    echo "copy .env.example to .env, and fill it out"
+    echo "maybe ask colleagues for an existing slack app key and config"
+    echo "then, run 'docker-compose up' to start server"
+fi

--- a/bin/composer
+++ b/bin/composer
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec docker-compose run -it dev-container composer "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,28 @@
+x-require-environment-file: &require-environment
+  environment:
+    - ENVIRONMENT
+    - RELEASE
+    - SECURITY_SALT
+    - MAIN_DOMAIN
+    - DATABASE_HOST
+    - DATABASE_USER
+    - DATABASE_PASSWORD
+    - DATABASE_NAME
+    - LOG_DEBUG_URL
+    - LOG_ERROR_URL
+    - SLACK_CLIENT_ID
+    - SLACK_CLIENT_SECRET
+    - SLACK_SIGNING_SECRET
+    - SLACK_TEAM_ID
+    - SLACK_REDIRECT_URI
+    - SLACK_BOT_USER_OAUTH_TOKEN
+    - SENTRY_BACKEND_DSN
+    - SENTRY_FRONTEND_DSN
+    - SENTRY_MONITOR_ID
+    - POTAL_TOKEN
+    - POTATO_CHANNEL
+    - POTATO_SLACK_USER_ID
+
 version: '3.1'
 services:
   backend:
@@ -5,34 +30,12 @@ services:
       context: .
       dockerfile: ./docker/backend/Dockerfile
       target: php-local
-    environment:
-        - ENVIRONMENT
-        - RELEASE
-        - SECURITY_SALT
-        - MAIN_DOMAIN
-        - DATABASE_HOST
-        - DATABASE_USER
-        - DATABASE_PASSWORD
-        - DATABASE_NAME
-        - LOG_DEBUG_URL
-        - LOG_ERROR_URL
-        - SLACK_CLIENT_ID
-        - SLACK_CLIENT_SECRET
-        - SLACK_SIGNING_SECRET
-        - SLACK_TEAM_ID
-        - SLACK_REDIRECT_URI
-        - SLACK_BOT_USER_OAUTH_TOKEN
-        - SENTRY_BACKEND_DSN
-        - SENTRY_FRONTEND_DSN
-        - SENTRY_MONITOR_ID
-        - POTAL_TOKEN
-        - POTATO_CHANNEL
-        - POTATO_SLACK_USER_ID
     depends_on:
       - db
       - potal
     ports:
       - 8080:8080
+    <<: *require-environment
     volumes:
       - .:/var/www/gib-potato:consistent
     networks:
@@ -73,6 +76,17 @@ services:
       gib-potato:
         aliases:
           - db.gib-potato.test
+
+  dev-container:
+    # Used from bin/composer
+    # Apply random profile name to ensure that 'docker-compose up' does not start this container
+    profiles: ["dockerized-php"]
+    build:
+      context: .
+      dockerfile: ./docker/backend/Dockerfile
+      target: php-build
+    volumes:
+      - .:/app
 
 volumes:
   db:


### PR DESCRIPTION
Like other sentry services, have an .envrc that does everything for you.

bin/composer is a shim around docker that runs composer from within
docker to bootstrap vendor/

No `brew install php composer` required!
