### PR TITLE
ref(backend): Forward DEBUG env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       dockerfile: ./docker/backend/Dockerfile
       target: php-local
     environment:
+        - DEBUG
         - ENVIRONMENT
         - RELEASE
         - SECURITY_SALT


### PR DESCRIPTION
To be able to enable CakePHP's debug mode locally, we need to pass the env via docker-compose.