### PR TITLE
fix(frontend): Remove product blur on out-of-stock items

### DIFF
--- a/frontend/src/views/Shop.vue
+++ b/frontend/src/views/Shop.vue
@@ -11,7 +11,6 @@
             <div
                 :index="index"
                 class="relative"
-                :class="{ 'blur-[2px]': product.stock === 0 }"
             >
                 <div class="relative h-72 w-full overflow-hidden rounded-lg">
                     <img class="h-full w-full object-cover object-center" :src="product.image_link">


### PR DESCRIPTION
Closes #142

**Before**

![image](https://github.com/getsentry/gib-potato/assets/6617432/c2217ab4-01cc-45f6-8a90-38be55fc9a61)

**After**

![image](https://github.com/getsentry/gib-potato/assets/6617432/9f28b8d4-2a51-4954-b13b-be0a2900d08e)

FYI @jas-kas 🙂 