### PR TITLE
fix(js): Add override for `@sentry/core`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1602,15 +1602,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@sentry-internal/browser-utils/node_modules/@sentry/core": {
-      "version": "9.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.0.0-alpha.0.tgz",
-      "integrity": "sha512-rznbdRvLTbb3zvujXAhaYRgcwB5P8GSmyR/2Qdr6RdGu6qWWQMG2j4iIcolLlXj1DUJfSTCFmbeRB+sk3WqaPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@sentry-internal/feedback": {
       "version": "9.0.0-alpha.0",
       "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-9.0.0-alpha.0.tgz",
@@ -1619,15 +1610,6 @@
       "dependencies": {
         "@sentry/core": "9.0.0-alpha.0"
       },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/feedback/node_modules/@sentry/core": {
-      "version": "9.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.0.0-alpha.0.tgz",
-      "integrity": "sha512-rznbdRvLTbb3zvujXAhaYRgcwB5P8GSmyR/2Qdr6RdGu6qWWQMG2j4iIcolLlXj1DUJfSTCFmbeRB+sk3WqaPQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -1658,24 +1640,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry/core": {
-      "version": "9.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.0.0-alpha.0.tgz",
-      "integrity": "sha512-rznbdRvLTbb3zvujXAhaYRgcwB5P8GSmyR/2Qdr6RdGu6qWWQMG2j4iIcolLlXj1DUJfSTCFmbeRB+sk3WqaPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/replay/node_modules/@sentry/core": {
-      "version": "9.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.0.0-alpha.0.tgz",
-      "integrity": "sha512-rznbdRvLTbb3zvujXAhaYRgcwB5P8GSmyR/2Qdr6RdGu6qWWQMG2j4iIcolLlXj1DUJfSTCFmbeRB+sk3WqaPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@sentry/babel-plugin-component-annotate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-3.0.0.tgz",
@@ -1697,15 +1661,6 @@
         "@sentry-internal/replay-canvas": "9.0.0-alpha.0",
         "@sentry/core": "9.0.0-alpha.0"
       },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/browser/node_modules/@sentry/core": {
-      "version": "9.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.0.0-alpha.0.tgz",
-      "integrity": "sha512-rznbdRvLTbb3zvujXAhaYRgcwB5P8GSmyR/2Qdr6RdGu6qWWQMG2j4iIcolLlXj1DUJfSTCFmbeRB+sk3WqaPQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -1892,13 +1847,11 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "8.51.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.51.0.tgz",
-      "integrity": "sha512-Go0KxCYLw+OBIlLSv5YsYX+x9NW43fNVcyB6rhkSp2Q5Zme3tAE6KtZFvyu4SO7G/903wisW5Q6qV6UuK/ee4A==",
-      "dev": true,
-      "license": "MIT",
+      "version": "9.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.0.0-alpha.0.tgz",
+      "integrity": "sha512-rznbdRvLTbb3zvujXAhaYRgcwB5P8GSmyR/2Qdr6RdGu6qWWQMG2j4iIcolLlXj1DUJfSTCFmbeRB+sk3WqaPQ==",
       "engines": {
-        "node": ">=14.18"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/vite-plugin": {
@@ -1952,15 +1905,6 @@
         "pinia": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@sentry/vue/node_modules/@sentry/core": {
-      "version": "9.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.0.0-alpha.0.tgz",
-      "integrity": "sha512-rznbdRvLTbb3zvujXAhaYRgcwB5P8GSmyR/2Qdr6RdGu6qWWQMG2j4iIcolLlXj1DUJfSTCFmbeRB+sk3WqaPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "prettier": "^3.4.2",
     "tailwindcss": "^3.4.17",
     "vite": "^6.0.11"
+  },
+  "overrides": {
+    "@sentry/core": "^9.0.0-alpha.0"
   }
 }


### PR DESCRIPTION
To ensure that a consistent version is used.
May be fixed by https://github.com/codecov/codecov-javascript-bundler-plugins/pull/242