### PR TITLE
fix(nit): redirect on Shop 'Gib Credit' button

### DIFF
--- a/frontend/src/views/Shop.vue
+++ b/frontend/src/views/Shop.vue
@@ -5,7 +5,12 @@
         </h2>
         <span class="mx-4">-</span>
         <span>Out of potato?</span>
-        <button class="ml-4 flex justify-center rounded-md border border-zinc-300 px-3 py-1 text-sm">Gib Credit</button>
+        <a
+            href="/gib-credit"
+            class="ml-4 flex justify-center rounded-md border border-zinc-300 px-3 py-1 text-sm"
+        >
+            Gib Credit
+        </a>
     </div>
 
     <div class="mt-16 grid grid-cols-1 gap-y-12 sm:grid-cols-2 sm:gap-x-6 lg:grid-cols-4 xl:gap-x-8 mb-32">


### PR DESCRIPTION
I just yoinked the other working buttons' code e.g. https://github.com/getsentry/gib-potato/blob/fa77f74d85c00453121f2996b0235a51e2a6f5e9/frontend/src/views/Stocks.vue#L9-L14