### PR TITLE
Fix spendable potato timezone bug

### DIFF
--- a/src/Model/Entity/User.php
+++ b/src/Model/Entity/User.php
@@ -226,7 +226,7 @@ class User extends Entity
         $totalSpent = (int)$totalSpentResult->spent;
 
         // Calculate spent in the last 90 days
-        $ninetyDaysAgo = DateTime::now()->subDays(90);
+        $ninetyDaysAgo = DateTime::now('UTC')->subDays(90);
         $last90DaysQuery = $purchasesTable->find();
         $last90DaysResult = $last90DaysQuery
             ->select([


### PR DESCRIPTION
Explicitly set UTC timezone for the 90-day spending window calculation in `spendablePotato`.

The previous implementation used the server's default timezone, which could lead to incorrect calculations when compared against UTC timestamps stored in the database. This change aligns the method with the application's UTC database configuration and other timezone-aware methods in the class.

---
<a href="https://cursor.com/background-agent?bcId=bc-64c891f5-d7d2-4610-aa61-efa0eb6b3d1e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-64c891f5-d7d2-4610-aa61-efa0eb6b3d1e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

