### PR TITLE
fix(potal): fix telemetry processor pinned version

### DIFF
--- a/potal/go.mod
+++ b/potal/go.mod
@@ -3,8 +3,8 @@ module github.com/getsentry/gib-potato
 go 1.26.0
 
 require (
-	github.com/getsentry/sentry-go v0.45.1-0.20260409100724-f12e2cdfe20a
-	github.com/getsentry/sentry-go/slog v0.45.1-0.20260409100724-f12e2cdfe20a
+	github.com/getsentry/sentry-go v0.45.1-0.20260410091754-cb84b35b8455
+	github.com/getsentry/sentry-go/slog v0.45.1-0.20260410091754-cb84b35b8455
 	github.com/google/go-cmp v0.5.9
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/slack-go/slack v0.20.0

--- a/potal/go.sum
+++ b/potal/go.sum
@@ -1,9 +1,9 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/getsentry/sentry-go v0.45.1-0.20260409100724-f12e2cdfe20a h1:TIQQsnToZ1MpsQZfBWPAuIyivuRaXbpr4gpNv/tCB54=
-github.com/getsentry/sentry-go v0.45.1-0.20260409100724-f12e2cdfe20a/go.mod h1:XDotiNZbgf5U8bPDUAfvcFmOnMQQceESxyKaObSssW0=
-github.com/getsentry/sentry-go/slog v0.45.1-0.20260409100724-f12e2cdfe20a h1:0ctpcIM3TTtWBQNbaS24oXOllqEsSzLL+6bKS+gSC+c=
-github.com/getsentry/sentry-go/slog v0.45.1-0.20260409100724-f12e2cdfe20a/go.mod h1:P04C1cKn7DgjnJ+/VBFdIEo2IJWdiMFwrWrkXM9082Y=
+github.com/getsentry/sentry-go v0.45.1-0.20260410091754-cb84b35b8455 h1:jP6IJzAJN+BeyWdtBr777ifHNCCAEazyjxoprhnjljA=
+github.com/getsentry/sentry-go v0.45.1-0.20260410091754-cb84b35b8455/go.mod h1:XDotiNZbgf5U8bPDUAfvcFmOnMQQceESxyKaObSssW0=
+github.com/getsentry/sentry-go/slog v0.45.1-0.20260410091754-cb84b35b8455 h1:Lg5XaslYqYD2E1+jpJ61CDY4qHUAoXiLYWVVv4pfgpQ=
+github.com/getsentry/sentry-go/slog v0.45.1-0.20260410091754-cb84b35b8455/go.mod h1:P04C1cKn7DgjnJ+/VBFdIEo2IJWdiMFwrWrkXM9082Y=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=


### PR DESCRIPTION
### Description

This PR is a follow-up to https://github.com/getsentry/gib-potato/pull/400.

The previous version of the processor didn't safely access sdkInfo when sending standalone client reports, due to not having an event to extract the event sdk info headers. Pinning the hash that enables the processor and fixes the issue.