### PR TITLE
fix(shopato): Bridge Cloud Run PORT to Thruster HTTP_PORT

### DIFF
--- a/shopato/bin/docker-entrypoint
+++ b/shopato/bin/docker-entrypoint
@@ -6,6 +6,11 @@ if [ -z "${LD_PRELOAD+x}" ]; then
     export LD_PRELOAD
 fi
 
+# Thruster listens on HTTP_PORT (default 80), but Cloud Run sends traffic to PORT.
+if [ -n "${PORT}" ] && [ -z "${HTTP_PORT}" ]; then
+    export HTTP_PORT="${PORT}"
+fi
+
 # If running the rails server then create or migrate existing database
 if [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then
   ./bin/rails db:prepare


### PR DESCRIPTION
Shopato deploys fail on Cloud Run because Thruster listens on `HTTP_PORT`
(default 80) while Cloud Run routes traffic to `PORT` (configured as 3000
in Terraform). The container never accepts the health check and times out.

The docker entrypoint now exports `HTTP_PORT=$PORT` when `PORT` is set,
so Thruster listens on the port Cloud Run expects. The bridge is skipped
when `HTTP_PORT` is already set explicitly, preserving override behavior.