### PR TITLE
fix(shopato): Derive TARGET_PORT to prevent Thruster/Puma port collision

### DIFF
--- a/shopato/bin/docker-entrypoint
+++ b/shopato/bin/docker-entrypoint
@@ -6,9 +6,12 @@ if [ -z "${LD_PRELOAD+x}" ]; then
     export LD_PRELOAD
 fi
 
-# Thruster listens on HTTP_PORT (default 80), but Cloud Run sends traffic to PORT.
+# Cloud Run sends traffic to PORT, but Thruster listens on HTTP_PORT (default 80)
+# and proxies to TARGET_PORT (default 3000). Thruster sets PORT=TARGET_PORT for the
+# child process (Puma), so we must ensure HTTP_PORT != TARGET_PORT.
 if [ -n "${PORT}" ] && [ -z "${HTTP_PORT}" ]; then
     export HTTP_PORT="${PORT}"
+    export TARGET_PORT="${TARGET_PORT:-3001}"
 fi
 
 # If running the rails server then create or migrate existing database

--- a/shopato/bin/docker-entrypoint
+++ b/shopato/bin/docker-entrypoint
@@ -6,12 +6,11 @@ if [ -z "${LD_PRELOAD+x}" ]; then
     export LD_PRELOAD
 fi
 
-# Cloud Run sends traffic to PORT, but Thruster listens on HTTP_PORT (default 80)
-# and proxies to TARGET_PORT (default 3000). Thruster sets PORT=TARGET_PORT for the
-# child process (Puma), so we must ensure HTTP_PORT != TARGET_PORT.
+# Cloud Run sends traffic to PORT, but Thruster listens on HTTP_PORT and proxies
+# to TARGET_PORT. Derive TARGET_PORT from HTTP_PORT so they never collide.
 if [ -n "${PORT}" ] && [ -z "${HTTP_PORT}" ]; then
     export HTTP_PORT="${PORT}"
-    export TARGET_PORT="${TARGET_PORT:-3001}"
+    export TARGET_PORT="${TARGET_PORT:-$((PORT + 1))}"
 fi
 
 # If running the rails server then create or migrate existing database


### PR DESCRIPTION
The PORT-to-HTTP_PORT bridge in #416 caused Thruster and Puma to both
bind to port 3000 on Cloud Run — the Terraform sets \`container_port = 3000\`,
and Thruster's default \`TARGET_PORT\` is also 3000, producing \`EADDRINUSE\`
or proxy EOF errors.

Derive \`TARGET_PORT\` as \`PORT + 1\` so the reverse proxy and the Rails
application always listen on distinct ports, regardless of the configured
\`container_port\`.