### PR TITLE
build(deps): Bump cakephp/cakephp from 5.3.4 to 5.3.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=8.5",
         "cakephp/authentication": "^3.3.5",
-        "cakephp/cakephp": "^5.3.4",
+        "cakephp/cakephp": "^5.3.5",
         "cakephp/migrations": "^5.1.1",
         "cakephp/plugin-installer": "^2.0.2",
         "lcobucci/jwt": "^5.6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "65e5750c0165460a2c4ddbb3a593ce32",
+    "content-hash": "141f502f1a96eb0cb9461444c419ced7",
     "packages": [
         {
             "name": "cakephp/authentication",
@@ -76,16 +76,16 @@
         },
         {
             "name": "cakephp/cakephp",
-            "version": "5.3.4",
+            "version": "5.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/cakephp.git",
-                "reference": "cffdbe1b6aca68ca29358cf95b372ef985646ce5"
+                "reference": "c6bd8670ac3d684fccf1f6735938078ea3ac1a47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/cakephp/zipball/cffdbe1b6aca68ca29358cf95b372ef985646ce5",
-                "reference": "cffdbe1b6aca68ca29358cf95b372ef985646ce5",
+                "url": "https://api.github.com/repos/cakephp/cakephp/zipball/c6bd8670ac3d684fccf1f6735938078ea3ac1a47",
+                "reference": "c6bd8670ac3d684fccf1f6735938078ea3ac1a47",
                 "shasum": ""
             },
             "require": {
@@ -193,7 +193,7 @@
                 "issues": "https://github.com/cakephp/cakephp/issues",
                 "source": "https://github.com/cakephp/cakephp"
             },
-            "time": "2026-04-17T15:05:22+00:00"
+            "time": "2026-05-09T03:17:01+00:00"
         },
         {
             "name": "cakephp/chronos",
@@ -4740,5 +4740,5 @@
         "php": ">=8.5"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Bump cakephp/cakephp from 5.3.4 to 5.3.5 to pick up the latest
patch release.