### PR TITLE
build: Use Node 24 for asset builds

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -77,12 +77,14 @@ steps:
   - '--region'
   - 'us-central1'
   waitFor: ['push-backend']
-- name: 'gcr.io/cloud-builders/npm'
+- name: 'node:24'
   id: 'npm-install'
-  args: ['install', '--frozen-lock'] 
+  entrypoint: npm
+  args: ['install', '--frozen-lock']
   waitFor: ['-']
-- name: 'gcr.io/cloud-builders/npm'
+- name: 'node:24'
   id: 'build-assets'
+  entrypoint: npm
   args: ['run', 'build']
   waitFor: ['npm-install']
   secretEnv: ['SENTRY_AUTH_TOKEN']

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -58,7 +58,7 @@ EXPOSE 8080
 
 CMD [ "/bin/bash", "/run.sh" ]
 
-FROM node:22-bullseye AS js-build
+FROM node:24-bullseye AS js-build
 
 WORKDIR /app
 


### PR DESCRIPTION
The Cloud Build asset steps ran on the deprecated `gcr.io/cloud-builders/npm` image, which ships Node 19. The frontend toolchain (Vite 8) requires Node `^20.19.0 || >=22.12.0`, so `npm run build` failed on Node 19.

**Cloud Build npm steps**

Both npm steps now run on the official `node:24` image with an explicit `npm` entrypoint instead of the deprecated builder image.

**Dockerfile parity**

The `js-build` stage moves from `node:22-bullseye` to `node:24-bullseye` so the container build and Cloud Build use the same Node version.