### PR TITLE
Show your API token on the profile

### DIFF
--- a/config/Migrations/20260710120000_AddApiTokensUserIdUnique.php
+++ b/config/Migrations/20260710120000_AddApiTokensUserIdUnique.php
@@ -15,15 +15,6 @@ class AddApiTokensUserIdUnique extends BaseMigration
      */
     public function up(): void
     {
-        // Remove duplicate tokens per user, keeping the most recently used
-        // (falling back to the most recently created) one.
-        $this->execute(
-            'DELETE FROM api_tokens WHERE id NOT IN (
-                SELECT DISTINCT ON (user_id) id FROM api_tokens
-                ORDER BY user_id, last_used DESC NULLS LAST, created DESC
-            )',
-        );
-
         $this->table('api_tokens')
             ->addIndex(['user_id'], ['unique' => true])
             ->update();

--- a/config/Migrations/20260710120000_AddApiTokensUserIdUnique.php
+++ b/config/Migrations/20260710120000_AddApiTokensUserIdUnique.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\BaseMigration;
+
+class AddApiTokensUserIdUnique extends BaseMigration
+{
+    /**
+     * Up Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        // Remove duplicate tokens per user, keeping the most recently used
+        // (falling back to the most recently created) one.
+        $this->execute(
+            'DELETE FROM api_tokens WHERE id NOT IN (
+                SELECT DISTINCT ON (user_id) id FROM api_tokens
+                ORDER BY user_id, last_used DESC NULLS LAST, created DESC
+            )',
+        );
+
+        $this->table('api_tokens')
+            ->addIndex(['user_id'], ['unique' => true])
+            ->update();
+    }
+
+    /**
+     * Down Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        $this->table('api_tokens')
+            ->removeIndex(['user_id'])
+            ->update();
+    }
+}

--- a/config/routes.php
+++ b/config/routes.php
@@ -74,6 +74,13 @@ return static function (RouteBuilder $routes): void {
 
             $builder->get('/user/profile', ['prefix' => 'Api', 'controller' => 'Users', 'action' => 'profile']);
 
+            $builder->get('/user/token', ['prefix' => 'Api', 'controller' => 'Users', 'action' => 'token']);
+            $builder->post('/user/token/regenerate', [
+                'prefix' => 'Api',
+                'controller' => 'Users',
+                'action' => 'regenerateToken',
+            ]);
+
             $builder->get('/shop/products', ['prefix' => 'Api', 'controller' => 'Shop', 'action' => 'products']);
             $builder->post('/shop/purchase', ['prefix' => 'Api', 'controller' => 'Shop', 'action' => 'purchase']);
 

--- a/frontend/src/views/Profile.vue
+++ b/frontend/src/views/Profile.vue
@@ -197,6 +197,7 @@ export default {
             } finally {
                 this.regenerating = false
                 this.confirmRegenerate = false
+                this.tokenVisible = false
             }
         },
     }

--- a/frontend/src/views/Profile.vue
+++ b/frontend/src/views/Profile.vue
@@ -39,29 +39,38 @@
             </p>
             <div class="mt-3 flex items-center gap-2">
                 <code
-                    class="flex-1 truncate rounded-md border border-zinc-300 bg-zinc-100 dark:bg-zinc-800 dark:border-zinc-600 px-3 py-2 text-sm"
+                    class="sentry-mask flex-1 truncate rounded-md border border-zinc-300 bg-zinc-100 dark:bg-zinc-800 dark:border-zinc-600 px-3 py-2 text-sm"
                 >{{ tokenVisible ? apiToken : '••••••••••••••••••••••••••••••••' }}</code>
                 <button
                     type="button"
-                    class="rounded-md border border-zinc-300 bg-zinc-100 px-3 py-2 text-sm font-medium text-zinc-900"
+                    class="rounded-md border border-zinc-300 bg-zinc-100 dark:bg-zinc-800 dark:border-zinc-600 dark:text-zinc-100 px-3 py-2 text-sm font-medium text-zinc-900"
                     @click="tokenVisible = !tokenVisible"
                 >
                     {{ tokenVisible ? 'Hide' : 'Show' }}
                 </button>
                 <button
                     type="button"
-                    class="rounded-md border border-zinc-300 bg-zinc-100 px-3 py-2 text-sm font-medium text-zinc-900"
+                    class="rounded-md border border-zinc-300 bg-zinc-100 dark:bg-zinc-800 dark:border-zinc-600 dark:text-zinc-100 px-3 py-2 text-sm font-medium text-zinc-900"
                     @click="copyToken"
                 >
                     {{ copied ? 'Copied!' : 'Copy' }}
                 </button>
                 <button
+                    v-if="!confirmRegenerate"
                     type="button"
                     class="rounded-md border border-transparent bg-amber-200 px-3 py-2 text-sm font-medium text-zinc-900"
+                    @click="confirmRegenerate = true"
+                >
+                    Regenerate
+                </button>
+                <button
+                    v-else
+                    type="button"
+                    class="rounded-md border border-transparent bg-red-400 px-3 py-2 text-sm font-medium text-zinc-900"
                     :disabled="regenerating"
                     @click="regenerateToken"
                 >
-                    {{ regenerating ? 'Regenerating…' : 'Regenerate' }}
+                    {{ regenerating ? 'Regenerating…' : 'Really? Old token stops working!' }}
                 </button>
             </div>
         </div>
@@ -144,6 +153,7 @@ export default {
             apiToken: '',
             tokenVisible: false,
             copied: false,
+            confirmRegenerate: false,
             regenerating: false,
         }
     },
@@ -186,6 +196,7 @@ export default {
                 console.log(error)
             } finally {
                 this.regenerating = false
+                this.confirmRegenerate = false
             }
         },
     }

--- a/frontend/src/views/Profile.vue
+++ b/frontend/src/views/Profile.vue
@@ -33,6 +33,39 @@
             </p>
         </div>
         <div class="py-4">
+            <h2 class="text-lg font-medium leading-6">Your API Token</h2>
+            <p class="mt-1 text-sm text-zinc-500">
+                Use this token to access the GibPotato API, e.g. <code>GET /api/leaderboard</code> with an <code>Authorization: Bearer</code> header.
+            </p>
+            <div class="mt-3 flex items-center gap-2">
+                <code
+                    class="flex-1 truncate rounded-md border border-zinc-300 bg-zinc-100 dark:bg-zinc-800 dark:border-zinc-600 px-3 py-2 text-sm"
+                >{{ tokenVisible ? apiToken : '••••••••••••••••••••••••••••••••' }}</code>
+                <button
+                    type="button"
+                    class="rounded-md border border-zinc-300 bg-zinc-100 px-3 py-2 text-sm font-medium text-zinc-900"
+                    @click="tokenVisible = !tokenVisible"
+                >
+                    {{ tokenVisible ? 'Hide' : 'Show' }}
+                </button>
+                <button
+                    type="button"
+                    class="rounded-md border border-zinc-300 bg-zinc-100 px-3 py-2 text-sm font-medium text-zinc-900"
+                    @click="copyToken"
+                >
+                    {{ copied ? 'Copied!' : 'Copy' }}
+                </button>
+                <button
+                    type="button"
+                    class="rounded-md border border-transparent bg-amber-200 px-3 py-2 text-sm font-medium text-zinc-900"
+                    :disabled="regenerating"
+                    @click="regenerateToken"
+                >
+                    {{ regenerating ? 'Regenerating…' : 'Regenerate' }}
+                </button>
+            </div>
+        </div>
+        <div class="py-4">
             <h2 class="text-lg font-medium leading-6">Your activity in the last 30 days</h2>
             <ul class="divide-y divide-zinc-300">
                 <li
@@ -107,11 +140,16 @@ export default {
     },
     data() {
         return {
-            messages: []
+            messages: [],
+            apiToken: '',
+            tokenVisible: false,
+            copied: false,
+            regenerating: false,
         }
     },
     mounted() {
         this.fetchMessages()
+        this.fetchToken()
     },
     methods: {
         async fetchMessages() {
@@ -120,6 +158,34 @@ export default {
                 this.messages = response.data
             } catch (error) {
                 console.log(error)
+            }
+        },
+        async fetchToken() {
+            try {
+                const response = await api.get('user/token')
+                this.apiToken = response.data.token
+            } catch (error) {
+                console.log(error)
+            }
+        },
+        async copyToken() {
+            try {
+                await navigator.clipboard.writeText(this.apiToken)
+                this.copied = true
+                setTimeout(() => this.copied = false, 2000)
+            } catch (error) {
+                console.log(error)
+            }
+        },
+        async regenerateToken() {
+            this.regenerating = true
+            try {
+                const response = await api.post('user/token/regenerate')
+                this.apiToken = response.data.token
+            } catch (error) {
+                console.log(error)
+            } finally {
+                this.regenerating = false
             }
         },
     }

--- a/src/Controller/Api/UsersController.php
+++ b/src/Controller/Api/UsersController.php
@@ -113,6 +113,53 @@ class UsersController extends ApiController
     /**
      * @return \Cake\Http\Response
      */
+    public function token(): Response
+    {
+        /** @var \App\Model\Table\ApiTokensTable $apiTokensTable */
+        $apiTokensTable = $this->fetchTable('ApiTokens');
+
+        $apiToken = $apiTokensTable->find()
+            ->where(['ApiTokens.user_id' => $this->Authentication->getIdentityData('id')])
+            ->first();
+
+        if ($apiToken === null) {
+            $usersTable = $this->fetchTable('Users');
+            /** @var \App\Model\Entity\User $user */
+            $user = $usersTable->get($this->Authentication->getIdentityData('id'));
+
+            $apiToken = $apiTokensTable->generateApiToken($user);
+        }
+
+        return $this->response
+            ->withStatus(200)
+            ->withType('json')
+            ->withStringBody(json_encode(['token' => $apiToken->token]));
+    }
+
+    /**
+     * @return \Cake\Http\Response
+     */
+    public function regenerateToken(): Response
+    {
+        $this->request->allowMethod('post');
+
+        $usersTable = $this->fetchTable('Users');
+        /** @var \App\Model\Entity\User $user */
+        $user = $usersTable->get($this->Authentication->getIdentityData('id'));
+
+        /** @var \App\Model\Table\ApiTokensTable $apiTokensTable */
+        $apiTokensTable = $this->fetchTable('ApiTokens');
+        $apiToken = $apiTokensTable->regenerateApiToken($user);
+
+        return $this->response
+            ->withStatus(200)
+            ->withType('json')
+            ->withStringBody(json_encode(['token' => $apiToken->token]));
+    }
+
+    /**
+     * @return \Cake\Http\Response
+     */
     public function profile(): Response
     {
         $messagesTable = $this->fetchTable('Messages');

--- a/src/Controller/Api/UsersController.php
+++ b/src/Controller/Api/UsersController.php
@@ -6,6 +6,7 @@ namespace App\Controller\Api;
 use App\Model\Entity\User;
 use Cake\Http\Response;
 use Cake\I18n\DateTime;
+use Cake\Utility\Security;
 
 /**
  * @property \Authentication\Controller\Component\AuthenticationComponent $Authentication
@@ -118,17 +119,10 @@ class UsersController extends ApiController
         /** @var \App\Model\Table\ApiTokensTable $apiTokensTable */
         $apiTokensTable = $this->fetchTable('ApiTokens');
 
+        /** @var \App\Model\Entity\ApiToken $apiToken */
         $apiToken = $apiTokensTable->find()
             ->where(['ApiTokens.user_id' => $this->Authentication->getIdentityData('id')])
-            ->first();
-
-        if ($apiToken === null) {
-            $usersTable = $this->fetchTable('Users');
-            /** @var \App\Model\Entity\User $user */
-            $user = $usersTable->get($this->Authentication->getIdentityData('id'));
-
-            $apiToken = $apiTokensTable->generateApiToken($user);
-        }
+            ->firstOrFail();
 
         return $this->response
             ->withStatus(200)
@@ -143,13 +137,24 @@ class UsersController extends ApiController
     {
         $this->request->allowMethod('post');
 
-        $usersTable = $this->fetchTable('Users');
-        /** @var \App\Model\Entity\User $user */
-        $user = $usersTable->get($this->Authentication->getIdentityData('id'));
-
         /** @var \App\Model\Table\ApiTokensTable $apiTokensTable */
         $apiTokensTable = $this->fetchTable('ApiTokens');
-        $apiToken = $apiTokensTable->regenerateApiToken($user);
+
+        /** @var \App\Model\Entity\ApiToken $apiToken */
+        $apiToken = $apiTokensTable->find()
+            ->where(['ApiTokens.user_id' => $this->Authentication->getIdentityData('id')])
+            ->firstOrFail();
+
+        $apiToken = $apiTokensTable->patchEntity($apiToken, [
+            'token' => Security::randomString(),
+            'last_used' => null,
+        ], [
+            'accessibleFields' => [
+                'token' => true,
+                'last_used' => true,
+            ],
+        ]);
+        $apiTokensTable->saveOrFail($apiToken);
 
         return $this->response
             ->withStatus(200)

--- a/src/Model/Table/ApiTokensTable.php
+++ b/src/Model/Table/ApiTokensTable.php
@@ -110,4 +110,29 @@ class ApiTokensTable extends Table
 
         return $this->saveOrFail($apiToken);
     }
+
+    /**
+     * @param \App\Model\Entity\User $user User.
+     * @return \App\Model\Entity\ApiToken
+     */
+    public function regenerateApiToken(User $user): ApiToken
+    {
+        $apiToken = $this->find()
+            ->where(['ApiTokens.user_id' => $user->id])
+            ->first();
+
+        if ($apiToken === null) {
+            return $this->generateApiToken($user);
+        }
+
+        $apiToken = $this->patchEntity($apiToken, [
+            'token' => Security::randomString(),
+        ], [
+            'accessibleFields' => [
+                'token' => true,
+            ],
+        ]);
+
+        return $this->saveOrFail($apiToken);
+    }
 }

--- a/src/Model/Table/ApiTokensTable.php
+++ b/src/Model/Table/ApiTokensTable.php
@@ -110,29 +110,4 @@ class ApiTokensTable extends Table
 
         return $this->saveOrFail($apiToken);
     }
-
-    /**
-     * @param \App\Model\Entity\User $user User.
-     * @return \App\Model\Entity\ApiToken
-     */
-    public function regenerateApiToken(User $user): ApiToken
-    {
-        $apiToken = $this->find()
-            ->where(['ApiTokens.user_id' => $user->id])
-            ->first();
-
-        if ($apiToken === null) {
-            return $this->generateApiToken($user);
-        }
-
-        $apiToken = $this->patchEntity($apiToken, [
-            'token' => Security::randomString(),
-        ], [
-            'accessibleFields' => [
-                'token' => true,
-            ],
-        ]);
-
-        return $this->saveOrFail($apiToken);
-    }
 }


### PR DESCRIPTION
Everyone already has an API token, but there's no way to actually see it without digging in the database.

Now the profile shows your token — so you can hit stuff like `/api/leaderboard` from wherever — plus a regenerate button in case you leak it in a screenshot 🥔