### PR TITLE
Make room for user emails

### DIFF
--- a/config/Migrations/20260710000000_AddUserSlackEmail.php
+++ b/config/Migrations/20260710000000_AddUserSlackEmail.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\BaseMigration;
+
+class AddUserSlackEmail extends BaseMigration
+{
+    /**
+     * Up Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-up-method
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        $this->table('users')
+            ->addColumn('slack_email', 'string', [
+                'after' => 'slack_name',
+                'default' => null,
+                'length' => 255,
+                'null' => true,
+            ])
+            ->update();
+    }
+
+    /**
+     * Down Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-down-method
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        $this->table('users')
+            ->removeColumn('slack_email')
+            ->update();
+    }
+}

--- a/src/Model/Entity/User.php
+++ b/src/Model/Entity/User.php
@@ -16,6 +16,7 @@ use Cake\ORM\Locator\LocatorAwareTrait;
  * @property string $role
  * @property string $slack_user_id
  * @property string $slack_name
+ * @property string|null $slack_email
  * @property string $slack_picture
  * @property string $slack_time_zone
  * @property bool $slack_is_bot
@@ -38,6 +39,15 @@ class User extends Entity
      */
     protected array $_accessible = [
         '*' => false,
+    ];
+
+    /**
+     * Fields that are excluded from JSON versions of the entity.
+     *
+     * @var array<string>
+     */
+    protected array $_hidden = [
+        'slack_email',
     ];
 
     public const STATUS_ACTIVE = 'active';

--- a/src/Model/Table/UsersTable.php
+++ b/src/Model/Table/UsersTable.php
@@ -109,6 +109,10 @@ class UsersTable extends Table
             ->notEmptyString('slack_name');
 
         $validator
+            ->email('slack_email')
+            ->allowEmptyString('slack_email');
+
+        $validator
             ->scalar('slack_picture')
             ->maxLength('slack_picture', 255)
             ->requirePresence('slack_picture', 'create')


### PR DESCRIPTION
We only know people by their Slack ID, which means nothing to any other system. First step to fixing that: give users an email field. (1/3 — filling it and exposing it come next.) 🥔