### PR TITLE
fix(backend): Scope spending limit to last 90 days

### DIFF
--- a/src/Model/Entity/User.php
+++ b/src/Model/Entity/User.php
@@ -209,24 +209,24 @@ class User extends Entity
      */
     public function spendablePotato(): int
     {
-        $pruchasesTable = $this->fetchTable('Purchases');
+        $purchasesTable = $this->fetchTable('Purchases');
 
-        $query = $pruchasesTable->find();
+        $query = $purchasesTable->find();
         $result = $query
             ->select([
                 'spent' => $query->func()->sum('price'),
             ])
             ->where([
                 'user_id' => $this->id,
+                'created >=' => DateTime::now('UTC')->subDays(90),
             ])
             ->first();
 
-        // @FIXME make this based on 90 days
         if ((int)$result->spent >= 500) {
             return 0;
         }
 
-        return $this->potatoReceived() - (int)$result->spent;
+        return max(0, $this->potatoReceived() - (int)$result->spent);
     }
 
     /**

--- a/tests/Fixture/PurchasesFixture.php
+++ b/tests/Fixture/PurchasesFixture.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * PurchasesFixture
+ */
+class PurchasesFixture extends TestFixture
+{
+    /**
+     * Init method
+     *
+     * @return void
+     */
+    public function init(): void
+    {
+        $this->records = [];
+        parent::init();
+    }
+}

--- a/tests/Fixture/UsersFixture.php
+++ b/tests/Fixture/UsersFixture.php
@@ -54,6 +54,18 @@ class UsersFixture extends TestFixture
                 'created' => '2023-01-01 00:00:00',
                 'modified' => '2023-01-01 00:00:00',
             ],
+            [
+                'id' => '00000000-0000-0000-0000-000000000004',
+                'status' => 'active',
+                'role' => 'user',
+                'slack_user_id' => 'U4444',
+                'slack_name' => 'User U4444',
+                'slack_picture' => 'https://example.com/U4444.jpg',
+                'slack_is_bot' => 0,
+                'slack_time_zone' => 'UTC',
+                'created' => '2023-01-01 00:00:00',
+                'modified' => '2023-01-01 00:00:00',
+            ],
         ];
         parent::init();
     }

--- a/tests/TestCase/Model/Entity/UserTest.php
+++ b/tests/TestCase/Model/Entity/UserTest.php
@@ -3,7 +3,9 @@ declare(strict_types=1);
 
 namespace App\Test\TestCase\Model\Entity;
 
+use App\Model\Entity\Message;
 use Cake\Chronos\Chronos;
+use Cake\I18n\DateTime;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -18,6 +20,8 @@ class UserTest extends TestCase
      */
     protected array $fixtures = [
         'app.Users',
+        'app.Messages',
+        'app.Purchases',
     ];
 
     /**
@@ -36,6 +40,11 @@ class UserTest extends TestCase
     protected $UserUS;
 
     /**
+     * @var \App\Model\Entity\User
+     */
+    protected $UserBuyer;
+
+    /**
      * setUp method
      *
      * @return void
@@ -49,6 +58,7 @@ class UserTest extends TestCase
         $this->UserEurope = $usersTable->get('00000000-0000-0000-0000-000000000001');
         $this->UserCanada = $usersTable->get('00000000-0000-0000-0000-000000000002');
         $this->UserUS = $usersTable->get('00000000-0000-0000-0000-000000000003');
+        $this->UserBuyer = $usersTable->get('00000000-0000-0000-0000-000000000004');
     }
 
     /**
@@ -61,6 +71,7 @@ class UserTest extends TestCase
         unset($this->UserEurope);
         unset($this->UserCanada);
         unset($this->UserUS);
+        unset($this->UserBuyer);
 
         Chronos::setTestNow();
 
@@ -120,5 +131,144 @@ class UserTest extends TestCase
         $this->assertSame('9', $this->UserEurope->potatoResetInHours());
         $this->assertSame('15', $this->UserCanada->potatoResetInHours());
         $this->assertSame('18', $this->UserUS->potatoResetInHours());
+    }
+
+    /**
+     * Test spendablePotato method with no purchases
+     *
+     * @return void
+     * @uses \App\Model\Entity\User::spendablePotato()
+     */
+    public function testSpendablePotatoWithNoPurchases(): void
+    {
+        Chronos::setTestNow(new Chronos('2024-07-17 12:00:00', 'UTC'));
+
+        $this->addReceivedPotatoes($this->UserBuyer, 100);
+
+        $this->assertSame(100, $this->UserBuyer->spendablePotato());
+    }
+
+    /**
+     * Test spendablePotato method returns zero when spending limit reached
+     *
+     * @return void
+     * @uses \App\Model\Entity\User::spendablePotato()
+     */
+    public function testSpendablePotatoReturnsZeroWhenLimitReached(): void
+    {
+        Chronos::setTestNow(new Chronos('2024-07-17 12:00:00', 'UTC'));
+
+        $this->addReceivedPotatoes($this->UserBuyer, 600);
+        $this->addPurchase($this->UserBuyer, 500, DateTime::now('UTC')->subDays(30));
+
+        $this->assertSame(0, $this->UserBuyer->spendablePotato());
+    }
+
+    /**
+     * Test spendablePotato method counts purchase at exactly 90 days
+     *
+     * @return void
+     * @uses \App\Model\Entity\User::spendablePotato()
+     */
+    public function testSpendablePotatoCountsPurchaseAtExactly90Days(): void
+    {
+        Chronos::setTestNow(new Chronos('2024-07-17 12:00:00', 'UTC'));
+
+        $this->addReceivedPotatoes($this->UserBuyer, 600);
+        $this->addPurchase($this->UserBuyer, 500, DateTime::now('UTC')->subDays(90));
+
+        $this->assertSame(0, $this->UserBuyer->spendablePotato());
+    }
+
+    /**
+     * Test spendablePotato method ignores purchases older than 90 days
+     *
+     * @return void
+     * @uses \App\Model\Entity\User::spendablePotato()
+     */
+    public function testSpendablePotatoIgnoresPurchasesOlderThan90Days(): void
+    {
+        Chronos::setTestNow(new Chronos('2024-07-17 12:00:00', 'UTC'));
+
+        $this->addReceivedPotatoes($this->UserBuyer, 600);
+        $this->addPurchase($this->UserBuyer, 500, DateTime::now('UTC')->subDays(91));
+
+        $this->assertSame(600, $this->UserBuyer->spendablePotato());
+    }
+
+    /**
+     * Test spendablePotato method counts recent and ignores old purchases
+     *
+     * @return void
+     * @uses \App\Model\Entity\User::spendablePotato()
+     */
+    public function testSpendablePotatoCountsRecentAndIgnoresOldPurchases(): void
+    {
+        Chronos::setTestNow(new Chronos('2024-07-17 12:00:00', 'UTC'));
+
+        $this->addReceivedPotatoes($this->UserBuyer, 600);
+        $this->addPurchase($this->UserBuyer, 400, DateTime::now('UTC')->subDays(91));
+        $this->addPurchase($this->UserBuyer, 200, DateTime::now('UTC')->subDays(10));
+
+        $this->assertSame(400, $this->UserBuyer->spendablePotato());
+    }
+
+    /**
+     * Test spendablePotato method returns zero when multiple purchases exceed limit
+     *
+     * @return void
+     * @uses \App\Model\Entity\User::spendablePotato()
+     */
+    public function testSpendablePotatoReturnsZeroWhenMultiplePurchasesExceedLimit(): void
+    {
+        Chronos::setTestNow(new Chronos('2024-07-17 12:00:00', 'UTC'));
+
+        $this->addReceivedPotatoes($this->UserBuyer, 700);
+        $this->addPurchase($this->UserBuyer, 300, DateTime::now('UTC')->subDays(30));
+        $this->addPurchase($this->UserBuyer, 300, DateTime::now('UTC')->subDays(10));
+
+        $this->assertSame(0, $this->UserBuyer->spendablePotato());
+    }
+
+    /**
+     * Test spendablePotato method clamps to zero when spent exceeds received
+     *
+     * @return void
+     * @uses \App\Model\Entity\User::spendablePotato()
+     */
+    public function testSpendablePotatoClampsToZeroWhenSpentExceedsReceived(): void
+    {
+        Chronos::setTestNow(new Chronos('2024-07-17 12:00:00', 'UTC'));
+
+        $this->addReceivedPotatoes($this->UserBuyer, 50);
+        $this->addPurchase($this->UserBuyer, 200, DateTime::now('UTC')->subDays(30));
+
+        $this->assertSame(0, $this->UserBuyer->spendablePotato());
+    }
+
+    private function addReceivedPotatoes(\App\Model\Entity\User $user, int $amount): void
+    {
+        $messagesTable = $this->fetchTable('Messages');
+        $message = $messagesTable->newEntity([
+            'sender_user_id' => $user->id,
+            'receiver_user_id' => $user->id,
+            'type' => Message::TYPE_POTATO,
+            'amount' => $amount,
+        ], ['accessibleFields' => ['*' => true]]);
+        $messagesTable->saveOrFail($message);
+    }
+
+    private function addPurchase(\App\Model\Entity\User $user, int $price, DateTime $created): void
+    {
+        $purchasesTable = $this->fetchTable('Purchases');
+        $purchase = $purchasesTable->newEntity([
+            'user_id' => $user->id,
+            'name' => 'Test Product',
+            'description' => 'Test',
+            'image_link' => 'https://example.com/test.jpg',
+            'price' => $price,
+            'created' => $created,
+        ], ['accessibleFields' => ['*' => true]]);
+        $purchasesTable->saveOrFail($purchase);
     }
 }

--- a/tests/TestCase/Model/Entity/UserTest.php
+++ b/tests/TestCase/Model/Entity/UserTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace App\Test\TestCase\Model\Entity;
 
 use App\Model\Entity\Message;
+use App\Model\Entity\User;
 use Cake\Chronos\Chronos;
 use Cake\I18n\DateTime;
 use Cake\TestSuite\TestCase;
@@ -25,22 +26,22 @@ class UserTest extends TestCase
     ];
 
     /**
-     * @var \App\Model\Entity\User
+     * @var User
      */
     protected $UserEurope;
 
     /**
-     * @var \App\Model\Entity\User
+     * @var User
      */
     protected $UserCanada;
 
     /**
-     * @var \App\Model\Entity\User
+     * @var User
      */
     protected $UserUS;
 
     /**
-     * @var \App\Model\Entity\User
+     * @var User
      */
     protected $UserBuyer;
 
@@ -82,7 +83,7 @@ class UserTest extends TestCase
      * Test getStartOfDay method
      *
      * @return void
-     * @uses \App\Model\Entity\User::getStartOfDay()
+     * @uses User::getStartOfDay()
      */
     public function testGetStartOfDay(): void
     {
@@ -102,7 +103,7 @@ class UserTest extends TestCase
      * Test getEndOfDay method
      *
      * @return void
-     * @uses \App\Model\Entity\User::getEndOfDay()
+     * @uses User::getEndOfDay()
      */
     public function testGetEndOfDay(): void
     {
@@ -122,7 +123,7 @@ class UserTest extends TestCase
      * Test potatoResetInHours method
      *
      * @return void
-     * @uses \App\Model\Entity\User::potatoResetInHours()
+     * @uses User::potatoResetInHours()
      */
     public function testPotatoResetInHours(): void
     {
@@ -137,7 +138,7 @@ class UserTest extends TestCase
      * Test spendablePotato method with no purchases
      *
      * @return void
-     * @uses \App\Model\Entity\User::spendablePotato()
+     * @uses User::spendablePotato()
      */
     public function testSpendablePotatoWithNoPurchases(): void
     {
@@ -152,7 +153,7 @@ class UserTest extends TestCase
      * Test spendablePotato method returns zero when spending limit reached
      *
      * @return void
-     * @uses \App\Model\Entity\User::spendablePotato()
+     * @uses User::spendablePotato()
      */
     public function testSpendablePotatoReturnsZeroWhenLimitReached(): void
     {
@@ -168,7 +169,7 @@ class UserTest extends TestCase
      * Test spendablePotato method counts purchase at exactly 90 days
      *
      * @return void
-     * @uses \App\Model\Entity\User::spendablePotato()
+     * @uses User::spendablePotato()
      */
     public function testSpendablePotatoCountsPurchaseAtExactly90Days(): void
     {
@@ -184,7 +185,7 @@ class UserTest extends TestCase
      * Test spendablePotato method ignores purchases older than 90 days
      *
      * @return void
-     * @uses \App\Model\Entity\User::spendablePotato()
+     * @uses User::spendablePotato()
      */
     public function testSpendablePotatoIgnoresPurchasesOlderThan90Days(): void
     {
@@ -200,7 +201,7 @@ class UserTest extends TestCase
      * Test spendablePotato method counts recent and ignores old purchases
      *
      * @return void
-     * @uses \App\Model\Entity\User::spendablePotato()
+     * @uses User::spendablePotato()
      */
     public function testSpendablePotatoCountsRecentAndIgnoresOldPurchases(): void
     {
@@ -217,7 +218,7 @@ class UserTest extends TestCase
      * Test spendablePotato method returns zero when multiple purchases exceed limit
      *
      * @return void
-     * @uses \App\Model\Entity\User::spendablePotato()
+     * @uses User::spendablePotato()
      */
     public function testSpendablePotatoReturnsZeroWhenMultiplePurchasesExceedLimit(): void
     {
@@ -234,7 +235,7 @@ class UserTest extends TestCase
      * Test spendablePotato method clamps to zero when spent exceeds received
      *
      * @return void
-     * @uses \App\Model\Entity\User::spendablePotato()
+     * @uses User::spendablePotato()
      */
     public function testSpendablePotatoClampsToZeroWhenSpentExceedsReceived(): void
     {
@@ -246,7 +247,7 @@ class UserTest extends TestCase
         $this->assertSame(0, $this->UserBuyer->spendablePotato());
     }
 
-    private function addReceivedPotatoes(\App\Model\Entity\User $user, int $amount): void
+    private function addReceivedPotatoes(User $user, int $amount): void
     {
         $messagesTable = $this->fetchTable('Messages');
         $message = $messagesTable->newEntity([
@@ -258,7 +259,7 @@ class UserTest extends TestCase
         $messagesTable->saveOrFail($message);
     }
 
-    private function addPurchase(\App\Model\Entity\User $user, int $price, DateTime $created): void
+    private function addPurchase(User $user, int $price, DateTime $created): void
     {
         $purchasesTable = $this->fetchTable('Purchases');
         $purchase = $purchasesTable->newEntity([


### PR DESCRIPTION
The spendablePotato() query previously summed all purchases ever, blocking users who had spent 500 potatoes lifetime from buying anything. Now scoped to the last 90 days as intended.

Also clamp the return value to zero to prevent negative results, and fix the $pruchasesTable typo.