### PR TITLE
chore(deps): Bump phpstan/phpstan from 1.12.33 to 2.2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "cakephp/bake": "^3.7.1",
         "cakephp/cakephp-codesniffer": "^5.3.1",
-        "phpstan/phpstan": "^1.12.33",
+        "phpstan/phpstan": "^2.2.5",
         "phpunit/phpunit": "^10.5.64"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "65957dc861355a9b12b0323f05645636",
+    "content-hash": "c2c9b214f79f3c8acc9c595d7c92ee19",
     "packages": [
         {
             "name": "cakephp/authentication",
@@ -2859,15 +2859,15 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.33",
+            "version": "2.2.5",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/37982d6fc7cbb746dda7773530cda557cdf119e1",
-                "reference": "37982d6fc7cbb746dda7773530cda557cdf119e1",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
+                "reference": "909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2|^8.0"
+                "php": "^7.4|^8.0"
             },
             "conflict": {
                 "phpstan/phpstan-shim": "*"
@@ -2885,6 +2885,17 @@
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "keywords": [
@@ -2908,7 +2919,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-28T20:30:03+00:00"
+            "time": "2026-07-05T06:31:06+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,5 @@
 parameters:
     level: 1
-    treatPhpDocTypesAsCertain: false
     bootstrapFiles:
         - config/paths.php
     paths:


### PR DESCRIPTION
- Update version constraint to ^2.2.5
- Remove `treatPhpDocTypesAsCertain` parameter from phpstan.neon (removed in PHPStan 2.0)