### PR TITLE
fix(backend): Cap spendable potato at quarterly limit and deduct prior purchases

### DIFF
--- a/src/Model/Entity/User.php
+++ b/src/Model/Entity/User.php
@@ -212,10 +212,10 @@ class User extends Entity
     {
         $purchasesTable = $this->fetchTable('Purchases');
 
-        $query = $purchasesTable->find();
-        $result = $query
+        $recentQuery = $purchasesTable->find();
+        $recentResult = $recentQuery
             ->select([
-                'spent' => $query->func()->sum('price'),
+                'spent' => $recentQuery->func()->sum('price'),
             ])
             ->where([
                 'user_id' => $this->id,
@@ -223,11 +223,22 @@ class User extends Entity
             ])
             ->first();
 
-        if ((int)$result->spent >= 500) {
-            return 0;
-        }
+        $totalQuery = $purchasesTable->find();
+        $totalResult = $totalQuery
+            ->select([
+                'spent' => $totalQuery->func()->sum('price'),
+            ])
+            ->where([
+                'user_id' => $this->id,
+            ])
+            ->first();
 
-        return max(0, $this->potatoReceived() - (int)$result->spent);
+        $recentSpent = (int)$recentResult->spent;
+        $totalSpent = (int)$totalResult->spent;
+        $remainingQuota = 500 - $recentSpent;
+        $remainingBalance = $this->potatoReceived() - $totalSpent;
+
+        return max(0, min($remainingQuota, $remainingBalance));
     }
 
     /**

--- a/tests/TestCase/Model/Entity/UserTest.php
+++ b/tests/TestCase/Model/Entity/UserTest.php
@@ -187,7 +187,7 @@ class UserTest extends TestCase
         $this->addReceivedPotatoes($this->UserBuyer, 600);
         $this->addPurchase($this->UserBuyer, 500, DateTime::now('UTC')->subDays(91));
 
-        $this->assertSame(600, $this->UserBuyer->spendablePotato());
+        $this->assertSame(100, $this->UserBuyer->spendablePotato());
     }
 
     /**
@@ -203,7 +203,7 @@ class UserTest extends TestCase
         $this->addPurchase($this->UserBuyer, 400, DateTime::now('UTC')->subDays(91));
         $this->addPurchase($this->UserBuyer, 200, DateTime::now('UTC')->subDays(10));
 
-        $this->assertSame(400, $this->UserBuyer->spendablePotato());
+        $this->assertSame(0, $this->UserBuyer->spendablePotato());
     }
 
     /**


### PR DESCRIPTION
`spendablePotato()` had two bugs: it did not cap the return value at the 500
quarterly limit, and purchases older than 90 days were excluded from the balance
calculation entirely — so expired purchases restored spendable potato as if
they never happened.

The method now enforces two independent constraints and returns the lesser:

- **Quarterly quota**: 500 minus purchases in the last 90 days.
- **Actual balance**: total received minus all-time purchases.

A user with 2095 received potato and no recent spending previously saw 2095 as
spendable; they now correctly see 500.