### PR TITLE
fix(potal): Pass correct ctx to potal client

### DIFF
--- a/potal/handler.go
+++ b/potal/handler.go
@@ -36,6 +36,14 @@ func (h *Handler) emitEventMetric(ctx context.Context, name string, eventType st
 	)
 }
 
+func cloneHubFromContext(ctx context.Context) *sentry.Hub {
+	hub := sentry.GetHubFromContext(ctx)
+	if hub == nil {
+		hub = sentry.CurrentHub()
+	}
+	return hub.Clone()
+}
+
 func DefaultHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	// Overwrite transaction source with something usefull
 	ctx := r.Context()
@@ -107,11 +115,7 @@ func (h *Handler) EventsHandler(w http.ResponseWriter, r *http.Request, _ httpro
 			switch ev.ChannelType {
 			case "im":
 				// Handle direct messages to the bot separately
-				hub := sentry.GetHubFromContext(ctx)
-				if hub == nil {
-					hub = sentry.CurrentHub()
-				}
-				hub = hub.Clone()
+				hub := cloneHubFromContext(ctx)
 				go func() {
 					ctx := sentry.SetHubOnContext(context.Background(), hub)
 
@@ -142,8 +146,8 @@ func (h *Handler) EventsHandler(w http.ResponseWriter, r *http.Request, _ httpro
 					txn.Status = sentry.SpanStatusOK
 				}()
 			default:
+				hub := cloneHubFromContext(ctx)
 				go func() {
-					hub := sentry.CurrentHub().Clone()
 					ctx := sentry.SetHubOnContext(context.Background(), hub)
 
 					options := []sentry.SpanOption{
@@ -175,8 +179,8 @@ func (h *Handler) EventsHandler(w http.ResponseWriter, r *http.Request, _ httpro
 			}
 		case *slackevents.ReactionAddedEvent:
 			go event.ProcessReactionEvent(r.Context(), ev, h.slackClient)
+			hub := cloneHubFromContext(ctx)
 			go func() {
-				hub := sentry.CurrentHub().Clone()
 				ctx := sentry.SetHubOnContext(context.Background(), hub)
 
 				options := []sentry.SpanOption{
@@ -208,8 +212,8 @@ func (h *Handler) EventsHandler(w http.ResponseWriter, r *http.Request, _ httpro
 			}()
 		case *slackevents.AppMentionEvent:
 			go event.ProcessAppMentionEvent(r.Context(), ev)
+			hub := cloneHubFromContext(ctx)
 			go func() {
-				hub := sentry.CurrentHub().Clone()
 				ctx := sentry.SetHubOnContext(context.Background(), hub)
 
 				options := []sentry.SpanOption{
@@ -241,8 +245,8 @@ func (h *Handler) EventsHandler(w http.ResponseWriter, r *http.Request, _ httpro
 			}()
 		case *slackevents.AppHomeOpenedEvent:
 			go event.ProcessAppHomeOpenedEvent(r.Context(), ev)
+			hub := cloneHubFromContext(ctx)
 			go func() {
-				hub := sentry.CurrentHub().Clone()
 				ctx := sentry.SetHubOnContext(context.Background(), hub)
 
 				options := []sentry.SpanOption{
@@ -274,8 +278,8 @@ func (h *Handler) EventsHandler(w http.ResponseWriter, r *http.Request, _ httpro
 			}()
 		case *slackevents.LinkSharedEvent:
 			go event.ProcessLinkSharedEvent(r.Context(), ev)
+			hub := cloneHubFromContext(ctx)
 			go func() {
-				hub := sentry.CurrentHub().Clone()
 				ctx := sentry.SetHubOnContext(context.Background(), hub)
 
 				options := []sentry.SpanOption{
@@ -329,8 +333,8 @@ func (h *Handler) SlashHandler(w http.ResponseWriter, r *http.Request, _ httprou
 
 	switch s.Command {
 	case "/gibopinion":
+		hub := cloneHubFromContext(ctx)
 		go func() {
-			hub := sentry.CurrentHub().Clone()
 			ctx := sentry.SetHubOnContext(context.Background(), hub)
 
 			options := []sentry.SpanOption{
@@ -388,8 +392,8 @@ func (h *Handler) InteractionsHandler(w http.ResponseWriter, r *http.Request, _ 
 
 	switch payload.Type {
 	case slack.InteractionTypeBlockActions:
+		hub := cloneHubFromContext(ctx)
 		go func() {
-			hub := sentry.CurrentHub().Clone()
 			ctx := sentry.SetHubOnContext(context.Background(), hub)
 
 			options := []sentry.SpanOption{

--- a/potal/handler.go
+++ b/potal/handler.go
@@ -107,8 +107,12 @@ func (h *Handler) EventsHandler(w http.ResponseWriter, r *http.Request, _ httpro
 			switch ev.ChannelType {
 			case "im":
 				// Handle direct messages to the bot separately
+				hub := sentry.GetHubFromContext(ctx)
+				if hub == nil {
+					hub = sentry.CurrentHub()
+				}
+				hub = hub.Clone()
 				go func() {
-					hub := sentry.CurrentHub().Clone()
 					ctx := sentry.SetHubOnContext(context.Background(), hub)
 
 					options := []sentry.SpanOption{


### PR DESCRIPTION
This fixes potal so that the client gets the correct cloned hub on `SendRequest`. Previously the handler was cloning the currenthub and when capturing a message and this resulted in all http request information to be lost.