### PR TITLE
chore(deps): Fix npm audit advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3182,15 +3182,15 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/browserslist": {
@@ -4228,9 +4228,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.16",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "funding": [
                 {
                     "type": "github",
@@ -4529,9 +4529,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.22",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-            "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+            "version": "8.5.26",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+            "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -4548,7 +4548,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.16",
+                "nanoid": "^3.3.17",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },


### PR DESCRIPTION
## What

Bump three transitive dependencies to clear the outstanding npm audit advisories. `npm audit` now reports 0 vulnerabilities.

- `brace-expansion` 5.0.7 to 5.0.9 (GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895, high)
- `postcss` 8.5.22 to 8.5.26 (GHSA-fxqj-rqcc-2cmp, moderate)
- `nanoid` 3.3.16 to 3.3.18 (pulled along by postcss)

Lockfile only, no direct dependency or source changes.

## Why

Two advisories were sitting on main: a DoS in `brace-expansion` reached through `minimatch`, and an arbitrary `.map` file read in `postcss` reached through `vite` and `@vue/compiler-sfc`. Both fixes are semver-compatible.