### PR TITLE
fix(potal|backend): Cancel pending vouchers on reaction removal

### DIFF
--- a/potal/handler.go
+++ b/potal/handler.go
@@ -178,7 +178,6 @@ func (h *Handler) EventsHandler(w http.ResponseWriter, r *http.Request, _ httpro
 				}()
 			}
 		case *slackevents.ReactionAddedEvent:
-			go event.ProcessReactionEvent(r.Context(), ev, h.slackClient)
 			hub := cloneHubFromContext(ctx)
 			go func() {
 				ctx := sentry.SetHubOnContext(context.Background(), hub)
@@ -208,6 +207,38 @@ func (h *Handler) EventsHandler(w http.ResponseWriter, r *http.Request, _ httpro
 				}
 
 				h.emitEventMetric(txn.Context(), "potal.event.forwarded", "reaction_added")
+				txn.Status = sentry.SpanStatusOK
+			}()
+		case *slackevents.ReactionRemovedEvent:
+			hub := cloneHubFromContext(ctx)
+			go func() {
+				ctx := sentry.SetHubOnContext(context.Background(), hub)
+
+				options := []sentry.SpanOption{
+					sentry.WithOpName("event.handler"),
+					sentry.WithTransactionSource(sentry.SourceTask),
+					sentry.ContinueFromHeaders(transaction.ToSentryTrace(), transaction.ToBaggage()),
+				}
+				txn := sentry.StartTransaction(ctx, "EVENT reaction_removed", options...)
+				txn.SetData("event_type", "reaction_removed")
+				defer txn.Finish()
+
+				processedEvent := event.ProcessReactionRemovedEvent(txn.Context(), ev, h.slackClient)
+				if processedEvent == nil {
+					h.emitEventMetric(txn.Context(), "potal.event.skipped", "reaction_removed")
+					slog.DebugContext(txn.Context(), "event skipped", "event_type", "reaction_removed")
+					txn.Status = sentry.SpanStatusInternalError
+					return
+				}
+				err := h.potalClient.SendRequest(txn.Context(), processedEvent)
+				if err != nil {
+					h.emitEventMetric(txn.Context(), "potal.event.forward_error", "reaction_removed")
+					slog.ErrorContext(txn.Context(), "failed to forward event", "event_type", "reaction_removed", "error", err)
+					txn.Status = sentry.SpanStatusInternalError
+					return
+				}
+
+				h.emitEventMetric(txn.Context(), "potal.event.forwarded", "reaction_removed")
 				txn.Status = sentry.SpanStatusOK
 			}()
 		case *slackevents.AppMentionEvent:

--- a/potal/internal/event/event.go
+++ b/potal/internal/event/event.go
@@ -10,6 +10,7 @@ const (
 	message             PotalEventType = "message"
 	directMessage       PotalEventType = "direct_message"
 	reactionAdded       PotalEventType = "reaction_added"
+	reactionRemoved     PotalEventType = "reaction_removed"
 	appMention          PotalEventType = "app_mention"
 	appHomeOpened       PotalEventType = "app_home_opened"
 	slashCommand        PotalEventType = "slash_command"

--- a/potal/internal/event/reactionremoved.go
+++ b/potal/internal/event/reactionremoved.go
@@ -1,0 +1,72 @@
+package event
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/getsentry/gib-potato/internal/constants"
+	"github.com/getsentry/sentry-go"
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+)
+
+type ReactionRemovedEvent struct {
+	Type      PotalEventType `json:"type"`
+	Sender    string         `json:"sender"`
+	Channel   string         `json:"channel"`
+	Reaction  string         `json:"reaction"`
+	Timestamp string         `json:"timestamp"`
+
+	IsBot bool `json:"-"`
+}
+
+func (e ReactionRemovedEvent) isValid() bool {
+	return e.Reaction == constants.PotatoVoucher && !e.IsBot
+}
+
+func ProcessReactionRemovedEvent(ctx context.Context, e *slackevents.ReactionRemovedEvent, sc *slack.Client) *ReactionRemovedEvent {
+	hub := sentry.GetHubFromContext(ctx)
+	txn := sentry.TransactionFromContext(ctx)
+
+	span := txn.StartChild("event.process", sentry.WithDescription("Process ReactionRemoved Event"))
+	defer span.Finish()
+
+	userSpan := span.StartChild("http.client")
+	userSpan.Description = "GET https://slack.com/api/users.info"
+
+	user, err := sc.GetUserInfo(e.User)
+	if err != nil {
+		userSpan.Status = sentry.SpanStatusInternalError
+		hub.CaptureException(err)
+		slog.ErrorContext(ctx, "failed to get user", "error", err, "user", e.User)
+		return nil
+	} else {
+		userSpan.Status = sentry.SpanStatusOK
+	}
+	userSpan.Finish()
+
+	removedEvent := ReactionRemovedEvent{
+		Reaction: e.Reaction,
+		IsBot:    user.IsBot,
+	}
+
+	if !removedEvent.isValid() {
+		span.Status = sentry.SpanStatusInvalidArgument
+		return nil
+	}
+
+	removedEvent = ReactionRemovedEvent{
+		Type:      reactionRemoved,
+		Sender:    e.User,
+		Channel:   e.Item.Channel,
+		Reaction:  ":" + e.Reaction + ":",
+		Timestamp: e.Item.Timestamp,
+	}
+
+	span.Status = sentry.SpanStatusOK
+
+	hub.Scope().SetContext("event", sentry.Context{"data": removedEvent})
+	hub.Scope().SetTag("event_type", reactionRemoved.String())
+
+	return &removedEvent
+}

--- a/src/Event/AbstractEvent.php
+++ b/src/Event/AbstractEvent.php
@@ -14,6 +14,7 @@ abstract class AbstractEvent
     public const TYPE_MESSAGE = 'message';
     public const TYPE_DIRECT_MESSAGE = 'direct_message';
     public const TYPE_REACTION_ADDED = 'reaction_added';
+    public const TYPE_REACTION_REMOVED = 'reaction_removed';
     public const TYPE_APP_HOME_OPENED = 'app_home_opened';
     public const TYPE_APP_MENTION = 'app_mention';
     public const TYPE_SLASH_COMMAND = 'slash_command';

--- a/src/Event/EventFactory.php
+++ b/src/Event/EventFactory.php
@@ -32,6 +32,7 @@ class EventFactory
             AbstractEvent::TYPE_MESSAGE => new MessageEvent($data),
             AbstractEvent::TYPE_DIRECT_MESSAGE => new DirectMessageEvent($data),
             AbstractEvent::TYPE_REACTION_ADDED => new ReactionAddedEvent($data),
+            AbstractEvent::TYPE_REACTION_REMOVED => new ReactionRemovedEvent($data),
             AbstractEvent::TYPE_APP_MENTION => new AppMentionEvent($data),
             AbstractEvent::TYPE_APP_HOME_OPENED => new AppHomeOpenedEvent($data),
             AbstractEvent::TYPE_SLASH_COMMAND => new SlashCommandEvent($data),

--- a/src/Event/ReactionRemovedEvent.php
+++ b/src/Event/ReactionRemovedEvent.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Event;
+
+use App\Service\UserService;
+use App\Service\VoucherService;
+
+class ReactionRemovedEvent extends AbstractEvent
+{
+    public string $sender;
+    public string $channel;
+    public string $reaction;
+    public string $timestamp;
+
+    /**
+     * @param array $event Event data.
+     */
+    public function __construct(array $event)
+    {
+        parent::__construct();
+
+        $this->type = self::TYPE_REACTION_REMOVED;
+        $this->sender = $event['sender'];
+        $this->channel = $event['channel'];
+        $this->reaction = $event['reaction'];
+        $this->timestamp = $event['timestamp'];
+        $this->eventTimestamp = $event['event_timestamp'] ?? '';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function process(): void
+    {
+        if ($this->reaction !== ':admission_tickets:') {
+            return;
+        }
+
+        $userService = new UserService();
+        $voucherService = new VoucherService();
+
+        $fromUser = $userService->getOrCreateUser($this->sender);
+
+        $voucherService->cancel(
+            fromUser: $fromUser,
+            channel: $this->channel,
+            timestamp: $this->timestamp,
+        );
+    }
+}

--- a/src/Service/VoucherService.php
+++ b/src/Service/VoucherService.php
@@ -72,4 +72,38 @@ class VoucherService
             );
         }
     }
+
+    /**
+     * @param \App\Model\Entity\User $fromUser User who removed the reaction.
+     * @param string $channel The channel.
+     * @param string $timestamp The message timestamp.
+     * @return void
+     */
+    public function cancel(
+        User $fromUser,
+        string $channel,
+        string $timestamp,
+    ): void {
+        $vouchersTable = $this->fetchTable('Vouchers');
+
+        $vouchers = $vouchersTable->find()
+            ->where([
+                'sender_user_id' => $fromUser->id,
+                'channel' => $channel,
+                'timestamp' => $timestamp,
+                'status' => Voucher::STATUS_PENDING,
+            ])
+            ->all();
+
+        foreach ($vouchers as $voucher) {
+            $vouchersTable->deleteOrFail($voucher);
+
+            logger()->info(
+                message: '"%s" cancelled a potato voucher 🎟️',
+                values: [
+                    $fromUser->slack_name,
+                ],
+            );
+        }
+    }
 }

--- a/tests/TestCase/Controller/EventsControllerTest.php
+++ b/tests/TestCase/Controller/EventsControllerTest.php
@@ -246,6 +246,64 @@ class EventsControllerTest extends TestCase
         $this->assertSame(5, $vouchers->count());
     }
 
+    public function testTypeReactionRemovedVoucher(): void
+    {
+        $vouchersTable = $this->fetchTable('Vouchers');
+        $voucher = $vouchersTable->newEntity([
+            'sender_user_id' => '00000000-0000-0000-0000-000000000001',
+            'receiver_user_id' => '00000000-0000-0000-0000-000000000002',
+            'channel' => 'C1111',
+            'timestamp' => '1672531200',
+            'permalink' => 'https://example.com/permalink',
+            'status' => 'pending',
+        ], ['accessibleFields' => ['*' => true]]);
+        $vouchersTable->saveOrFail($voucher);
+
+        $this->post('/events', json_encode([
+            'type' => 'reaction_removed',
+            'sender' => 'U1111',
+            'channel' => 'C1111',
+            'reaction' => ':admission_tickets:',
+            'timestamp' => '1672531200',
+            'event_timestamp' => '1672531200',
+        ]));
+
+        $this->assertResponseOk();
+        $this->assertHeader('Content-Type', 'application/json');
+
+        $vouchers = $vouchersTable->find()->all();
+        $this->assertSame(0, $vouchers->count());
+    }
+
+    public function testTypeReactionRemovedVoucherDoesNotDeleteRedeemed(): void
+    {
+        $vouchersTable = $this->fetchTable('Vouchers');
+        $voucher = $vouchersTable->newEntity([
+            'sender_user_id' => '00000000-0000-0000-0000-000000000001',
+            'receiver_user_id' => '00000000-0000-0000-0000-000000000002',
+            'channel' => 'C1111',
+            'timestamp' => '1672531200',
+            'permalink' => 'https://example.com/permalink',
+            'status' => 'redeemed',
+        ], ['accessibleFields' => ['*' => true]]);
+        $vouchersTable->saveOrFail($voucher);
+
+        $this->post('/events', json_encode([
+            'type' => 'reaction_removed',
+            'sender' => 'U1111',
+            'channel' => 'C1111',
+            'reaction' => ':admission_tickets:',
+            'timestamp' => '1672531200',
+            'event_timestamp' => '1672531200',
+        ]));
+
+        $this->assertResponseOk();
+
+        $vouchers = $vouchersTable->find()->all();
+        $this->assertSame(1, $vouchers->count());
+        $this->assertSame('redeemed', $vouchers->first()->status);
+    }
+
     public function testTypeAppMentionEvent(): void
     {
         $this->post('/events', json_encode([


### PR DESCRIPTION
Removing an `:admission_tickets:` reaction in Slack now deletes the matching pending vouchers. Previously the `reaction_removed` event was silently dropped by Potal, so vouchers created by mistake could not be undone before midnight redemption.

Potal validates the removed reaction is `:admission_tickets:` and the user is not a bot, then forwards sender, channel, and message timestamp to the backend. The backend finds pending vouchers matching those three fields and deletes them. Already-redeemed vouchers are unaffected.

Also removes a duplicate fire-and-forget `ProcessReactionEvent` call in the `reaction_added` handler that was processing every reaction twice.