### PR TITLE
feat(backend): Notify voucher receiver on redemption

### DIFF
--- a/src/Command/RedeemVouchersCommand.php
+++ b/src/Command/RedeemVouchersCommand.php
@@ -178,6 +178,17 @@ class RedeemVouchersCommand extends Command
                     );
                 }
 
+                if ($voucher->receiver_user->notifications['vouchers'] === true) {
+                    $slackClient->postMessage(
+                        channel: $voucher->receiver_user->slack_user_id,
+                        text: sprintf(
+                            'You received *1* :potato: from <@%s> via a :admission_tickets:!' . PHP_EOL . '> %s',
+                            $voucher->sender_user->slack_user_id,
+                            $voucher->permalink,
+                        ),
+                    );
+                }
+
                 trace_metrics()->count(
                     'gibpotato.vouchers.redeemed',
                     1.0,

--- a/src/Command/RedeemVouchersCommand.php
+++ b/src/Command/RedeemVouchersCommand.php
@@ -178,7 +178,7 @@ class RedeemVouchersCommand extends Command
                     );
                 }
 
-                if ($voucher->receiver_user->notifications['vouchers'] === true) {
+                if ($voucher->receiver_user->notifications['received'] === true) {
                     $slackClient->postMessage(
                         channel: $voucher->receiver_user->slack_user_id,
                         text: sprintf(


### PR DESCRIPTION
When a potato voucher is redeemed, the receiver now gets a DM telling them they received a potato and from whom. Previously only the sender was notified. The notification respects the receiver's `vouchers` notification preference, matching the existing sender behavior.