### PR TITLE
chore(potal): Disable HTTP body capture in Sentry SDK

### DIFF
--- a/potal/main.go
+++ b/potal/main.go
@@ -25,6 +25,9 @@ func main() {
 		SendDefaultPII:   true,
 		EnableTracing:    true,
 		TracesSampleRate: 1.0,
+		DataCollection: &sentry.DataCollection{
+			HTTPBodies: []sentry.BodyType{},
+		},
 	})
 	if sentryErr != nil {
 		log.Fatalf("An Error Occured: %v", sentryErr)


### PR DESCRIPTION
Set `DataCollection.HTTPBodies` to an empty slice so the SDK stops attaching
request bodies.