### PR TITLE
ref(potal): Scrub message text before forwarding to backend

### DIFF
--- a/potal/internal/event/appmention.go
+++ b/potal/internal/event/appmention.go
@@ -3,6 +3,7 @@ package event
 import (
 	"context"
 
+	"github.com/getsentry/gib-potato/internal/utils"
 	"github.com/getsentry/sentry-go"
 	"github.com/slack-go/slack/slackevents"
 )
@@ -33,7 +34,7 @@ func ProcessAppMentionEvent(ctx context.Context, e *slackevents.AppMentionEvent)
 		Type:           appMention,
 		Sender:         e.User,
 		Channel:        e.Channel,
-		Text:           e.Text,
+		Text:           utils.ScrubText(e.Text),
 		EventTimestamp: e.EventTimeStamp,
 		BotID:          e.BotID,
 	}

--- a/potal/internal/event/message.go
+++ b/potal/internal/event/message.go
@@ -79,6 +79,7 @@ func ProcessMessageEvent(ctx context.Context, e *slackevents.MessageEvent, sc *s
 	permalinkSpan.Finish()
 
 	messageEvent.Permalink = permalink
+	messageEvent.Text = utils.ScrubText(messageEvent.Text)
 
 	hub.Scope().SetContext("event", sentry.Context{"data": messageEvent})
 	hub.Scope().SetTag("event_type", message.String())

--- a/potal/internal/event/reactionadded.go
+++ b/potal/internal/event/reactionadded.go
@@ -122,7 +122,7 @@ func ProcessReactionEvent(ctx context.Context, e *slackevents.ReactionAddedEvent
 		Sender:          e.User,
 		Receivers:       utils.ReactionReceivers(text, e.User, e.ItemUser),
 		Channel:         e.Item.Channel,
-		Text:            text,
+		Text:            utils.ScrubText(text),
 		Reaction:        ":" + e.Reaction + ":",
 		Permalink:       permalink,
 		Timestamp:       e.Item.Timestamp,

--- a/potal/internal/utils/scrub.go
+++ b/potal/internal/utils/scrub.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/getsentry/gib-potato/internal/constants"
+)
+
+var scrubPattern = regexp.MustCompile(`<@[^>]+>|:` + constants.Potato + `:|:` + constants.PotatoVoucher + `:`)
+
+func ScrubText(text string) string {
+	matches := scrubPattern.FindAllString(text, -1)
+	return strings.Join(matches, " ")
+}

--- a/potal/internal/utils/scrub_test.go
+++ b/potal/internal/utils/scrub_test.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestScrubText(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"", ""},
+		{":potato:", ":potato:"},
+		{":admission_tickets:", ":admission_tickets:"},
+		{"<@U123ABC>", "<@U123ABC>"},
+		{"<@U123ABC> :potato: great work!", "<@U123ABC> :potato:"},
+		{"hey <@U123ABC> <@U456DEF> :potato::potato: you rock", "<@U123ABC> <@U456DEF> :potato: :potato:"},
+		{"just some random text", ""},
+		{":potato: :admission_tickets: <@U123ABC>", ":potato: :admission_tickets: <@U123ABC>"},
+	}
+
+	for _, test := range tests {
+		got := ScrubText(test.input)
+		if diff := cmp.Diff(test.want, got); diff != "" {
+			t.Errorf("ScrubText(%q) (-want +got):\n%s", test.input, diff)
+		}
+	}
+}

--- a/potal/main.go
+++ b/potal/main.go
@@ -25,6 +25,9 @@ func main() {
 		SendDefaultPII:   true,
 		EnableTracing:    true,
 		TracesSampleRate: 1.0,
+		DataCollection: &sentry.DataCollection{
+			HTTPBodies: []sentry.BodyType{},
+		},
 	})
 	if sentryErr != nil {
 		log.Fatalf("An Error Occured: %v", sentryErr)


### PR DESCRIPTION
Potal now strips Slack message text down to only `:potato:`, `:admission_tickets:`, and user mentions (`<@U…>`) before forwarding events to the backend. Previously the full raw message was sent, which meant arbitrary user content flowed through both the backend payload and the Sentry scope context.

The scrub applies to `MessageEvent`, `ReactionAddedEvent`, and `AppMentionEvent`. `DirectMessageEvent` and `SlashCommandEvent` are unchanged since their processing depends on the raw text.