### PR TITLE
chore(deps): Bump Sentry JS SDK to 11.0.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,8 @@
         "": {
             "name": "gib-potato",
             "dependencies": {
-                "@sentry/bundler-plugins": "^11.0.0-alpha.0",
-                "@sentry/vue": "^11.0.0-alpha.0",
+                "@sentry/bundler-plugins": "^11.0.0-alpha.1",
+                "@sentry/vue": "^11.0.0-alpha.1",
                 "@tailwindcss/vite": "^4.3.3",
                 "axios": "^1.19.0",
                 "vue": "^3.5.41",
@@ -1372,44 +1372,45 @@
             "license": "MIT"
         },
         "node_modules/@sentry/browser": {
-            "version": "11.0.0-alpha.0",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/browser/-/browser-11.0.0-alpha.0.tgz",
-            "integrity": "sha512-lZYOYAkDf2UOf/LBPKq642/Bb1g3Ew+IrhHz3axeSWSsX6bsbeFSWgdxEmxU3mOlaTOWQfiSV7MA906ZxqNnWw==",
+            "version": "11.0.0-alpha.1",
+            "resolved": "https://sfw.security.sentry.io/npm/@sentry/browser/-/browser-11.0.0-alpha.1.tgz",
+            "integrity": "sha512-KNwvVzbJSn7y9RTYW5I8dBrtSSZj+orzA4/c7Zhp1peH4J073fPWpIXJUeim2Sr5HvC0oRwbRqpYgrRrZ64bdg==",
             "license": "MIT",
             "dependencies": {
-                "@sentry/browser-utils": "11.0.0-alpha.0",
-                "@sentry/conventions": "^0.16.0",
-                "@sentry/core": "11.0.0-alpha.0",
-                "@sentry/feedback": "11.0.0-alpha.0",
-                "@sentry/replay": "11.0.0-alpha.0",
-                "@sentry/replay-canvas": "11.0.0-alpha.0"
+                "@sentry/browser-utils": "11.0.0-alpha.1",
+                "@sentry/conventions": "^0.19.0",
+                "@sentry/core": "11.0.0-alpha.1",
+                "@sentry/feedback": "11.0.0-alpha.1",
+                "@sentry/replay": "11.0.0-alpha.1",
+                "@sentry/replay-canvas": "11.0.0-alpha.1"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.12.0 <23.0.0 || >=23.2.0"
             }
         },
         "node_modules/@sentry/browser-utils": {
-            "version": "11.0.0-alpha.0",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/browser-utils/-/browser-utils-11.0.0-alpha.0.tgz",
-            "integrity": "sha512-m66KuZQnaLJ41iV6q2g4kcsmk+mkhDaJyrolMuIua0PbDwYcige50O2PIN5kj4sRv30Jfme05VwAI1ZRT3Vzmg==",
+            "version": "11.0.0-alpha.1",
+            "resolved": "https://sfw.security.sentry.io/npm/@sentry/browser-utils/-/browser-utils-11.0.0-alpha.1.tgz",
+            "integrity": "sha512-MUbgDQQnUz27aErA0gyiQgt+Zu6ZdqTP7YT8WN9g3fbWSBg2yj94bZ06pw4422sxj1w0q7wvVsF7nVmU1fy0/A==",
             "license": "MIT",
             "dependencies": {
-                "@sentry/conventions": "^0.16.0",
-                "@sentry/core": "11.0.0-alpha.0"
+                "@sentry/conventions": "^0.19.0",
+                "@sentry/core": "11.0.0-alpha.1",
+                "web-vitals": "^6.0.1"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.12.0 <23.0.0 || >=23.2.0"
             }
         },
         "node_modules/@sentry/bundler-plugins": {
-            "version": "11.0.0-alpha.0",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/bundler-plugins/-/bundler-plugins-11.0.0-alpha.0.tgz",
-            "integrity": "sha512-uLxHj0Z9fWDouq3LT4aAxukkUrz4nCYhOdW73IMziAYLFdhf1wJSv3K8ysjZLWtUng+dQ+J2admH7FVYCcf2xg==",
+            "version": "11.0.0-alpha.1",
+            "resolved": "https://sfw.security.sentry.io/npm/@sentry/bundler-plugins/-/bundler-plugins-11.0.0-alpha.1.tgz",
+            "integrity": "sha512-vFYrP4a2tKPkkFmuxg2c45XqhNnn07olYwP7blFLqD4QMd7blfvB0WnC0xpmke4CUYMl+ELhWbt8KgfyiV/qLg==",
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.18.5",
                 "@sentry/cli": "^2.58.6",
-                "@sentry/core": "11.0.0-alpha.0",
+                "@sentry/core": "11.0.0-alpha.1",
                 "dotenv": "^17.4.2",
                 "find-up": "^5.0.0",
                 "glob": "^13.0.6",
@@ -1598,73 +1599,73 @@
             }
         },
         "node_modules/@sentry/conventions": {
-            "version": "0.16.0",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/conventions/-/conventions-0.16.0.tgz",
-            "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+            "version": "0.19.0",
+            "resolved": "https://sfw.security.sentry.io/npm/@sentry/conventions/-/conventions-0.19.0.tgz",
+            "integrity": "sha512-nYciB7Pt/Ujf6pJSt1FnHeJBp908P5Ibod4FMlTzASJcqU1RvixI5EFzkbe8gvUxP3XAMoWDgeWeG8agCjKYVA==",
             "license": "MIT",
             "engines": {
                 "node": ">=14"
             }
         },
         "node_modules/@sentry/core": {
-            "version": "11.0.0-alpha.0",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/core/-/core-11.0.0-alpha.0.tgz",
-            "integrity": "sha512-YAwpmevzT3ghURwdLFDOFN74rZXE9VYYsgc+wsk5j8TQ6Nd+CLO2LvQvQbzxUmVJa6pN04z2oqWg+TWMpfH9QA==",
+            "version": "11.0.0-alpha.1",
+            "resolved": "https://sfw.security.sentry.io/npm/@sentry/core/-/core-11.0.0-alpha.1.tgz",
+            "integrity": "sha512-KIiN6A7QltDlPZ+OJAOfDpzfxGBUsubJoLOKV1T1pj/9KWdfQlb6V0iCPPON+SwqHTWC8YifdenmC0J5jq5BCA==",
             "license": "MIT",
             "dependencies": {
-                "@sentry/conventions": "^0.16.0"
+                "@sentry/conventions": "^0.19.0"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.12.0 <23.0.0 || >=23.2.0"
             }
         },
         "node_modules/@sentry/feedback": {
-            "version": "11.0.0-alpha.0",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/feedback/-/feedback-11.0.0-alpha.0.tgz",
-            "integrity": "sha512-q8fDu3pI45wHxl2920UD0m+cHQEjW176IS26j4TX1dT2idGE6n6NIIrJCBOYeTXh5PSkxd2BA4J1tUdHrzgY4g==",
+            "version": "11.0.0-alpha.1",
+            "resolved": "https://sfw.security.sentry.io/npm/@sentry/feedback/-/feedback-11.0.0-alpha.1.tgz",
+            "integrity": "sha512-rNlEjr/HhNqWK6DjiebDbsFzVyVCz5lH2pj4/Ev/xlLOgCxufvIrUFHXxpTAUXdMq/Dbxpa6JdU0Ltc3eEUgNg==",
             "license": "MIT",
             "dependencies": {
-                "@sentry/core": "11.0.0-alpha.0"
+                "@sentry/core": "11.0.0-alpha.1"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.12.0 <23.0.0 || >=23.2.0"
             }
         },
         "node_modules/@sentry/replay": {
-            "version": "11.0.0-alpha.0",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/replay/-/replay-11.0.0-alpha.0.tgz",
-            "integrity": "sha512-PElbKpmvap1ejMlEw2Z5tP2wroBtuh3Hq18V+7eDBAEcHfPh8N4DDJwu9quxPcb+OHn6VKHJE2LoJJPI8o/wMw==",
+            "version": "11.0.0-alpha.1",
+            "resolved": "https://sfw.security.sentry.io/npm/@sentry/replay/-/replay-11.0.0-alpha.1.tgz",
+            "integrity": "sha512-EiJOMXZisJ8KUf+XiLVwzPxND917M+DmMXMzY3o2NrYYHrNdoG5yLXqAaJmXQBcrVsVOmKprqJSa4svtl/9vGQ==",
             "license": "MIT",
             "dependencies": {
-                "@sentry/browser-utils": "11.0.0-alpha.0",
-                "@sentry/core": "11.0.0-alpha.0"
+                "@sentry/browser-utils": "11.0.0-alpha.1",
+                "@sentry/core": "11.0.0-alpha.1"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.12.0 <23.0.0 || >=23.2.0"
             }
         },
         "node_modules/@sentry/replay-canvas": {
-            "version": "11.0.0-alpha.0",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/replay-canvas/-/replay-canvas-11.0.0-alpha.0.tgz",
-            "integrity": "sha512-Rvtfmbrltx0isD9JpJZ0pmxx5jZKS3ZZWbH3HSH9RHHsNdHjKLWSzKcrX49Hf/XTGihO3YqiFxNll2aIT3SeIg==",
+            "version": "11.0.0-alpha.1",
+            "resolved": "https://sfw.security.sentry.io/npm/@sentry/replay-canvas/-/replay-canvas-11.0.0-alpha.1.tgz",
+            "integrity": "sha512-/rIBFLEjdWJ2RnkN1frh3xKi+aJ2jQpcTCATzRrpGcMMELL6vfFZIFAyN4L5UAhmxmu7ZXmXfpSEhj4hpf4YSQ==",
             "license": "MIT",
             "dependencies": {
-                "@sentry/core": "11.0.0-alpha.0",
-                "@sentry/replay": "11.0.0-alpha.0"
+                "@sentry/core": "11.0.0-alpha.1",
+                "@sentry/replay": "11.0.0-alpha.1"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.12.0 <23.0.0 || >=23.2.0"
             }
         },
         "node_modules/@sentry/vue": {
-            "version": "11.0.0-alpha.0",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/vue/-/vue-11.0.0-alpha.0.tgz",
-            "integrity": "sha512-1Em6K941gYYB5PwzK934OehDEpEEIQIMcEw8WMxnHp9Gup91wi4k1b42zH2uqPnXnSs9jgMOO4aTono7DOh+Og==",
+            "version": "11.0.0-alpha.1",
+            "resolved": "https://sfw.security.sentry.io/npm/@sentry/vue/-/vue-11.0.0-alpha.1.tgz",
+            "integrity": "sha512-ZfQ6RsrD0L6sFBFN9JCD+kG8R0k+GGqybOQYoE5lV8QB40laO2e+QyEZHPPkFhXuvWVhK2kpQWfl4PBwsWLPfw==",
             "license": "MIT",
             "dependencies": {
-                "@sentry/browser": "11.0.0-alpha.0",
-                "@sentry/conventions": "^0.16.0",
-                "@sentry/core": "11.0.0-alpha.0"
+                "@sentry/browser": "11.0.0-alpha.1",
+                "@sentry/conventions": "^0.19.0",
+                "@sentry/core": "11.0.0-alpha.1"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.12.0 <23.0.0 || >=23.2.0"
@@ -5789,6 +5790,12 @@
             "resolved": "https://sfw.security.sentry.io/npm/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
             "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
             "license": "MIT"
+        },
+        "node_modules/web-vitals": {
+            "version": "6.1.0",
+            "resolved": "https://sfw.security.sentry.io/npm/web-vitals/-/web-vitals-6.1.0.tgz",
+            "integrity": "sha512-ZNoJ/MbU6aaR2WjKrFVUvy5WQx+G96YvXQFSsmKTz3A/0VlAFywjUcxl00hc/S6wef2stfgQ4yWYIJCWCNudkA==",
+            "license": "Apache-2.0"
         },
         "node_modules/webidl-conversions": {
             "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
         "preview": "vp preview"
     },
     "dependencies": {
-        "@sentry/bundler-plugins": "^11.0.0-alpha.0",
-        "@sentry/vue": "^11.0.0-alpha.0",
+        "@sentry/bundler-plugins": "^11.0.0-alpha.1",
+        "@sentry/vue": "^11.0.0-alpha.1",
         "@tailwindcss/vite": "^4.3.3",
         "axios": "^1.19.0",
         "vue": "^3.5.41",


### PR DESCRIPTION
## What

Bump `@sentry/vue` and `@sentry/bundler-plugins` to `11.0.0-alpha.1`.

## Why

Keep the frontend on the latest Sentry v11 alpha.