### PR TITLE
ref(potal): Remove SendDefaultPII from Sentry SDK config

### DIFF
--- a/potal/main.go
+++ b/potal/main.go
@@ -22,7 +22,6 @@ func main() {
 		Release:          os.Getenv("RELEASE"),
 		Environment:      os.Getenv("ENVIRONMENT"),
 		AttachStacktrace: true,
-		SendDefaultPII:   true,
 		EnableTracing:    true,
 		TracesSampleRate: 1.0,
 		DataCollection: &sentry.DataCollection{


### PR DESCRIPTION
HTTP body capture is separately disabled via an empty HTTPBodies list, removing SendDefaultPII.