### PR TITLE
chore(deps): Bump Sentry JS SDK to 11.0.0-alpha.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,8 @@
             "name": "gib-potato",
             "dependencies": {
                 "@laravel/multiplex": "^0.4.3",
-                "@sentry/bundler-plugins": "^11.0.0-alpha.1",
-                "@sentry/vue": "^11.0.0-alpha.1",
+                "@sentry/bundler-plugins": "^11.0.0-alpha.2",
+                "@sentry/vue": "^11.0.0-alpha.2",
                 "@tailwindcss/vite": "^4.3.3",
                 "axios": "^1.20.0",
                 "vue": "^3.5.42",
@@ -1360,30 +1360,30 @@
             "license": "MIT"
         },
         "node_modules/@sentry/browser": {
-            "version": "11.0.0-alpha.1",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/browser/-/browser-11.0.0-alpha.1.tgz",
-            "integrity": "sha512-KNwvVzbJSn7y9RTYW5I8dBrtSSZj+orzA4/c7Zhp1peH4J073fPWpIXJUeim2Sr5HvC0oRwbRqpYgrRrZ64bdg==",
+            "version": "11.0.0-alpha.2",
+            "resolved": "https://sfw.security.sentry.io/npm/@sentry/browser/-/browser-11.0.0-alpha.2.tgz",
+            "integrity": "sha512-uRSfYolWGt4bBAq41wTp48ejK/wvyXW/QYQ8/vvlB2o1HgNcdaYZhPjHvkL4uDa19z+/dfEldSFRh0ZZP/w1qA==",
             "license": "MIT",
             "dependencies": {
-                "@sentry/browser-utils": "11.0.0-alpha.1",
-                "@sentry/conventions": "^0.19.0",
-                "@sentry/core": "11.0.0-alpha.1",
-                "@sentry/feedback": "11.0.0-alpha.1",
-                "@sentry/replay": "11.0.0-alpha.1",
-                "@sentry/replay-canvas": "11.0.0-alpha.1"
+                "@sentry/browser-utils": "11.0.0-alpha.2",
+                "@sentry/conventions": "^0.20.0",
+                "@sentry/core": "11.0.0-alpha.2",
+                "@sentry/feedback": "11.0.0-alpha.2",
+                "@sentry/replay": "11.0.0-alpha.2",
+                "@sentry/replay-canvas": "11.0.0-alpha.2"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.12.0 <23.0.0 || >=23.2.0"
             }
         },
         "node_modules/@sentry/browser-utils": {
-            "version": "11.0.0-alpha.1",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/browser-utils/-/browser-utils-11.0.0-alpha.1.tgz",
-            "integrity": "sha512-MUbgDQQnUz27aErA0gyiQgt+Zu6ZdqTP7YT8WN9g3fbWSBg2yj94bZ06pw4422sxj1w0q7wvVsF7nVmU1fy0/A==",
+            "version": "11.0.0-alpha.2",
+            "resolved": "https://sfw.security.sentry.io/npm/@sentry/browser-utils/-/browser-utils-11.0.0-alpha.2.tgz",
+            "integrity": "sha512-6jr3V9hqAsAJ7WgOd0TtJtmOgI9CCfv1utfW+2D9NxqcGy68fFbXeDucCSt8z0hFrEJaOSCejhvQva297P8xMA==",
             "license": "MIT",
             "dependencies": {
-                "@sentry/conventions": "^0.19.0",
-                "@sentry/core": "11.0.0-alpha.1",
+                "@sentry/conventions": "^0.20.0",
+                "@sentry/core": "11.0.0-alpha.2",
                 "web-vitals": "^6.0.1"
             },
             "engines": {
@@ -1391,18 +1391,18 @@
             }
         },
         "node_modules/@sentry/bundler-plugins": {
-            "version": "11.0.0-alpha.1",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/bundler-plugins/-/bundler-plugins-11.0.0-alpha.1.tgz",
-            "integrity": "sha512-vFYrP4a2tKPkkFmuxg2c45XqhNnn07olYwP7blFLqD4QMd7blfvB0WnC0xpmke4CUYMl+ELhWbt8KgfyiV/qLg==",
+            "version": "11.0.0-alpha.2",
+            "resolved": "https://sfw.security.sentry.io/npm/@sentry/bundler-plugins/-/bundler-plugins-11.0.0-alpha.2.tgz",
+            "integrity": "sha512-cWTtt94lsNmZTGo8Rr0IDilfc4wuuaDnEvhoZqvuo2RJixMtwr3Erq9S1nbiX4jnP2fcLNnZm8nc/R4BbLIHrg==",
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.18.5",
-                "@sentry/cli": "^2.58.6",
-                "@sentry/core": "11.0.0-alpha.1",
+                "@sentry/core": "11.0.0-alpha.2",
                 "dotenv": "^17.4.2",
                 "find-up": "^5.0.0",
                 "glob": "^13.0.6",
                 "magic-string": "~0.30.8",
+                "sentry": "^0.44.0",
                 "supports-color": "^8.1.1"
             },
             "engines": {
@@ -1421,239 +1421,74 @@
                 }
             }
         },
-        "node_modules/@sentry/cli": {
-            "version": "2.58.6",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/cli/-/cli-2.58.6.tgz",
-            "integrity": "sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==",
-            "hasInstallScript": true,
-            "license": "FSL-1.1-MIT",
-            "dependencies": {
-                "https-proxy-agent": "^5.0.0",
-                "node-fetch": "^2.6.7",
-                "progress": "^2.0.3",
-                "proxy-from-env": "^1.1.0",
-                "which": "^2.0.2"
-            },
-            "bin": {
-                "sentry-cli": "bin/sentry-cli"
-            },
-            "engines": {
-                "node": ">= 10"
-            },
-            "optionalDependencies": {
-                "@sentry/cli-darwin": "2.58.6",
-                "@sentry/cli-linux-arm": "2.58.6",
-                "@sentry/cli-linux-arm64": "2.58.6",
-                "@sentry/cli-linux-i686": "2.58.6",
-                "@sentry/cli-linux-x64": "2.58.6",
-                "@sentry/cli-win32-arm64": "2.58.6",
-                "@sentry/cli-win32-i686": "2.58.6",
-                "@sentry/cli-win32-x64": "2.58.6"
-            }
-        },
-        "node_modules/@sentry/cli-darwin": {
-            "version": "2.58.6",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/cli-darwin/-/cli-darwin-2.58.6.tgz",
-            "integrity": "sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==",
-            "license": "FSL-1.1-MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@sentry/cli-linux-arm": {
-            "version": "2.58.6",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.6.tgz",
-            "integrity": "sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "FSL-1.1-MIT",
-            "optional": true,
-            "os": [
-                "linux",
-                "freebsd",
-                "android"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@sentry/cli-linux-arm64": {
-            "version": "2.58.6",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.6.tgz",
-            "integrity": "sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "FSL-1.1-MIT",
-            "optional": true,
-            "os": [
-                "linux",
-                "freebsd",
-                "android"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@sentry/cli-linux-i686": {
-            "version": "2.58.6",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.6.tgz",
-            "integrity": "sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==",
-            "cpu": [
-                "x86",
-                "ia32"
-            ],
-            "license": "FSL-1.1-MIT",
-            "optional": true,
-            "os": [
-                "linux",
-                "freebsd",
-                "android"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@sentry/cli-linux-x64": {
-            "version": "2.58.6",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.6.tgz",
-            "integrity": "sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "FSL-1.1-MIT",
-            "optional": true,
-            "os": [
-                "linux",
-                "freebsd",
-                "android"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@sentry/cli-win32-arm64": {
-            "version": "2.58.6",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.6.tgz",
-            "integrity": "sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "FSL-1.1-MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@sentry/cli-win32-i686": {
-            "version": "2.58.6",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.6.tgz",
-            "integrity": "sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==",
-            "cpu": [
-                "x86",
-                "ia32"
-            ],
-            "license": "FSL-1.1-MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@sentry/cli-win32-x64": {
-            "version": "2.58.6",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.6.tgz",
-            "integrity": "sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "FSL-1.1-MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@sentry/conventions": {
-            "version": "0.19.0",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/conventions/-/conventions-0.19.0.tgz",
-            "integrity": "sha512-nYciB7Pt/Ujf6pJSt1FnHeJBp908P5Ibod4FMlTzASJcqU1RvixI5EFzkbe8gvUxP3XAMoWDgeWeG8agCjKYVA==",
+            "version": "0.20.0",
+            "resolved": "https://sfw.security.sentry.io/npm/@sentry/conventions/-/conventions-0.20.0.tgz",
+            "integrity": "sha512-nAL3tL+xgom6Dbuxq0NCEZZfBNIrUspjDJRcMMRl3WLiBCSeZzNCa7an48IpnrZoVMpAi2NQ2v9rFU+EQziKuQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=14"
             }
         },
         "node_modules/@sentry/core": {
-            "version": "11.0.0-alpha.1",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/core/-/core-11.0.0-alpha.1.tgz",
-            "integrity": "sha512-KIiN6A7QltDlPZ+OJAOfDpzfxGBUsubJoLOKV1T1pj/9KWdfQlb6V0iCPPON+SwqHTWC8YifdenmC0J5jq5BCA==",
+            "version": "11.0.0-alpha.2",
+            "resolved": "https://sfw.security.sentry.io/npm/@sentry/core/-/core-11.0.0-alpha.2.tgz",
+            "integrity": "sha512-GvqlS+z2UxCy92nrH0PMYn/Xw5Tw40VNGkJ85G/C7S55O/NO3c8vU+oJG9/exCKgs/N+u7fSKYgPubuvaArkLQ==",
             "license": "MIT",
             "dependencies": {
-                "@sentry/conventions": "^0.19.0"
+                "@sentry/conventions": "^0.20.0"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.12.0 <23.0.0 || >=23.2.0"
             }
         },
         "node_modules/@sentry/feedback": {
-            "version": "11.0.0-alpha.1",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/feedback/-/feedback-11.0.0-alpha.1.tgz",
-            "integrity": "sha512-rNlEjr/HhNqWK6DjiebDbsFzVyVCz5lH2pj4/Ev/xlLOgCxufvIrUFHXxpTAUXdMq/Dbxpa6JdU0Ltc3eEUgNg==",
+            "version": "11.0.0-alpha.2",
+            "resolved": "https://sfw.security.sentry.io/npm/@sentry/feedback/-/feedback-11.0.0-alpha.2.tgz",
+            "integrity": "sha512-sbEoZ1wIgYBEg1ecDwBLy68djJxBM9bg4zVGR+2nrQ9TID8wDn08kw0TQiVzwg2EO6PGVvjj1ukviJRMiuS6qA==",
             "license": "MIT",
             "dependencies": {
-                "@sentry/core": "11.0.0-alpha.1"
+                "@sentry/core": "11.0.0-alpha.2"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.12.0 <23.0.0 || >=23.2.0"
             }
         },
         "node_modules/@sentry/replay": {
-            "version": "11.0.0-alpha.1",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/replay/-/replay-11.0.0-alpha.1.tgz",
-            "integrity": "sha512-EiJOMXZisJ8KUf+XiLVwzPxND917M+DmMXMzY3o2NrYYHrNdoG5yLXqAaJmXQBcrVsVOmKprqJSa4svtl/9vGQ==",
+            "version": "11.0.0-alpha.2",
+            "resolved": "https://sfw.security.sentry.io/npm/@sentry/replay/-/replay-11.0.0-alpha.2.tgz",
+            "integrity": "sha512-djxcu+7VSnFcGUaxH+McUyrTAo2JiKf0vwoFWF9ACJiYN3craSIWUlc0jopeoL0xD40piNBAQltbmh0WDf1Dwg==",
             "license": "MIT",
             "dependencies": {
-                "@sentry/browser-utils": "11.0.0-alpha.1",
-                "@sentry/core": "11.0.0-alpha.1"
+                "@sentry/browser-utils": "11.0.0-alpha.2",
+                "@sentry/core": "11.0.0-alpha.2"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.12.0 <23.0.0 || >=23.2.0"
             }
         },
         "node_modules/@sentry/replay-canvas": {
-            "version": "11.0.0-alpha.1",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/replay-canvas/-/replay-canvas-11.0.0-alpha.1.tgz",
-            "integrity": "sha512-/rIBFLEjdWJ2RnkN1frh3xKi+aJ2jQpcTCATzRrpGcMMELL6vfFZIFAyN4L5UAhmxmu7ZXmXfpSEhj4hpf4YSQ==",
+            "version": "11.0.0-alpha.2",
+            "resolved": "https://sfw.security.sentry.io/npm/@sentry/replay-canvas/-/replay-canvas-11.0.0-alpha.2.tgz",
+            "integrity": "sha512-Pui732KXikj5L1EJd8hsQ4GbhKhNaZ0aHSEdlNJRMQMYCIApvJCY9CM/j86NrEt8bY3ShLs46r8T1iyT4NRJfw==",
             "license": "MIT",
             "dependencies": {
-                "@sentry/core": "11.0.0-alpha.1",
-                "@sentry/replay": "11.0.0-alpha.1"
+                "@sentry/core": "11.0.0-alpha.2",
+                "@sentry/replay": "11.0.0-alpha.2"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.12.0 <23.0.0 || >=23.2.0"
             }
         },
         "node_modules/@sentry/vue": {
-            "version": "11.0.0-alpha.1",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/vue/-/vue-11.0.0-alpha.1.tgz",
-            "integrity": "sha512-ZfQ6RsrD0L6sFBFN9JCD+kG8R0k+GGqybOQYoE5lV8QB40laO2e+QyEZHPPkFhXuvWVhK2kpQWfl4PBwsWLPfw==",
+            "version": "11.0.0-alpha.2",
+            "resolved": "https://sfw.security.sentry.io/npm/@sentry/vue/-/vue-11.0.0-alpha.2.tgz",
+            "integrity": "sha512-F+HgkinrN5Yjck+ZZz7bt1EkpcC6iMS5PHNIzYoMAn8jdFuoN5aEmKJWz2bqfwXNvKnIG02U3xJAJo4xmSr0dQ==",
             "license": "MIT",
             "dependencies": {
-                "@sentry/browser": "11.0.0-alpha.1",
-                "@sentry/conventions": "^0.19.0",
-                "@sentry/core": "11.0.0-alpha.1"
+                "@sentry/browser": "11.0.0-alpha.2",
+                "@sentry/conventions": "^0.20.0",
+                "@sentry/core": "11.0.0-alpha.2"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.12.0 <23.0.0 || >=23.2.0"
@@ -4163,12 +3998,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/isexe": {
-            "version": "2.0.0",
-            "resolved": "https://sfw.security.sentry.io/npm/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-            "license": "ISC"
-        },
         "node_modules/jiti": {
             "version": "2.7.0",
             "resolved": "https://sfw.security.sentry.io/npm/jiti/-/jiti-2.7.0.tgz",
@@ -4664,26 +4493,6 @@
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
             }
         },
-        "node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://sfw.security.sentry.io/npm/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "license": "MIT",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/node-releases": {
             "version": "2.0.53",
             "resolved": "https://sfw.security.sentry.io/npm/node-releases/-/node-releases-2.0.53.tgz",
@@ -5037,21 +4846,6 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
-        "node_modules/progress": {
-            "version": "2.0.3",
-            "resolved": "https://sfw.security.sentry.io/npm/progress/-/progress-2.0.3.tgz",
-            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://sfw.security.sentry.io/npm/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-            "license": "MIT"
-        },
         "node_modules/quansync": {
             "version": "0.2.11",
             "resolved": "https://sfw.security.sentry.io/npm/quansync/-/quansync-0.2.11.tgz",
@@ -5180,6 +4974,18 @@
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/sentry": {
+            "version": "0.44.1",
+            "resolved": "https://sfw.security.sentry.io/npm/sentry/-/sentry-0.44.1.tgz",
+            "integrity": "sha512-LK+RJ2PFsJKM+P0D/zYC+M5gFB1ytfVONU9DVUqJu67YFlwnj3wGJkUzBhCS8R4iUqRdRTAYbFbRKTAe03rW/Q==",
+            "license": "FSL-1.1-Apache-2.0",
+            "bin": {
+                "sentry": "dist/bin.cjs"
+            },
+            "engines": {
+                "node": ">=20.0"
             }
         },
         "node_modules/siginfo": {
@@ -5412,12 +5218,6 @@
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://sfw.security.sentry.io/npm/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "license": "MIT"
         },
         "node_modules/type-fest": {
             "version": "5.8.0",
@@ -6109,47 +5909,16 @@
             "license": "MIT"
         },
         "node_modules/web-vitals": {
-            "version": "6.1.1",
-            "resolved": "https://sfw.security.sentry.io/npm/web-vitals/-/web-vitals-6.1.1.tgz",
-            "integrity": "sha512-r93gKnR6ZC2O8F3JrS0AAGIQ0v0OhXuyg4DAj2oG7K+GPkwXfUSc3ZcWeu50AsV5yIc6xxnTjERipJ6EvSw2vg==",
+            "version": "6.2.1",
+            "resolved": "https://sfw.security.sentry.io/npm/web-vitals/-/web-vitals-6.2.1.tgz",
+            "integrity": "sha512-rLcLXA2sx6+9dE88NHFubwTtGxpK4yYBLj6qHPdFoCaLr0cXGb4efOqtKLlm4loGA4OEKHIQKMKzZkKyOh5ctw==",
             "license": "Apache-2.0"
-        },
-        "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://sfw.security.sentry.io/npm/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "license": "BSD-2-Clause"
         },
         "node_modules/webpack-virtual-modules": {
             "version": "0.6.2",
             "resolved": "https://sfw.security.sentry.io/npm/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
             "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
             "license": "MIT"
-        },
-        "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://sfw.security.sentry.io/npm/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "license": "MIT",
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
-        },
-        "node_modules/which": {
-            "version": "2.0.2",
-            "resolved": "https://sfw.security.sentry.io/npm/which/-/which-2.0.2.tgz",
-            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "license": "ISC",
-            "dependencies": {
-                "isexe": "^2.0.0"
-            },
-            "bin": {
-                "node-which": "bin/node-which"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
         },
         "node_modules/why-is-node-running": {
             "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     },
     "dependencies": {
         "@laravel/multiplex": "^0.4.3",
-        "@sentry/bundler-plugins": "^11.0.0-alpha.1",
-        "@sentry/vue": "^11.0.0-alpha.1",
+        "@sentry/bundler-plugins": "^11.0.0-alpha.2",
+        "@sentry/vue": "^11.0.0-alpha.2",
         "@tailwindcss/vite": "^4.3.3",
         "axios": "^1.20.0",
         "vue": "^3.5.42",
@@ -34,7 +34,6 @@
     },
     "packageManager": "npm@12.0.2",
     "allowScripts": {
-        "@sentry/cli@2.58.6": true,
         "fsevents@2.3.3": true
     }
 }


### PR DESCRIPTION
## What

Bump the Sentry JS SDK to 11.0.0-alpha.2 and drop the now unused `@sentry/cli` allowScripts entry.

## Why

Keep the frontend on the latest v11 alpha so we catch breaking changes early.