### PR TITLE
test(potal): add new scopes support

### DIFF
--- a/potal/go.mod
+++ b/potal/go.mod
@@ -3,8 +3,8 @@ module github.com/getsentry/gib-potato
 go 1.26.0
 
 require (
-	github.com/getsentry/sentry-go v0.49.0
-	github.com/getsentry/sentry-go/slog v0.49.0
+	github.com/getsentry/sentry-go v0.49.1-0.20260902075538-3e956b7f89e4
+	github.com/getsentry/sentry-go/slog v0.49.1-0.20260902075538-3e956b7f89e4
 	github.com/google/go-cmp v0.7.0
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/slack-go/slack v0.29.0

--- a/potal/go.sum
+++ b/potal/go.sum
@@ -1,9 +1,9 @@
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/getsentry/sentry-go v0.49.0 h1:Ehejknu1l023Ub7QoRBVLAI7g3Jnhqku4oWx4B4Sh5s=
-github.com/getsentry/sentry-go v0.49.0/go.mod h1:nuMJAoCfe1u0Bts2ocyNI+TW8HT84vRMqwA5Qq/SKUI=
-github.com/getsentry/sentry-go/slog v0.49.0 h1:yqwJF00OSNY7AZQ5su40ajXKOcxW+A/ap4jTTNTMx+U=
-github.com/getsentry/sentry-go/slog v0.49.0/go.mod h1:icu7tMeOAGgAYJ5XU5ETe0mRuaT4JhIBKNAcBDcNHPg=
+github.com/getsentry/sentry-go v0.49.1-0.20260902075538-3e956b7f89e4 h1:Cm3JGyPl2nzOp1BiDsuMDycxcipFg+jA4uzbLxH6FiU=
+github.com/getsentry/sentry-go v0.49.1-0.20260902075538-3e956b7f89e4/go.mod h1:nuMJAoCfe1u0Bts2ocyNI+TW8HT84vRMqwA5Qq/SKUI=
+github.com/getsentry/sentry-go/slog v0.49.1-0.20260902075538-3e956b7f89e4 h1:fgH9T/cean8NxO4Sv/w9KFRd9VZ7y7eD/pFusNPSK7I=
+github.com/getsentry/sentry-go/slog v0.49.1-0.20260902075538-3e956b7f89e4/go.mod h1:icu7tMeOAGgAYJ5XU5ETe0mRuaT4JhIBKNAcBDcNHPg=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=

--- a/potal/handler.go
+++ b/potal/handler.go
@@ -40,12 +40,11 @@ func (h *Handler) emitEventMetric(ctx context.Context, name string, eventType st
 	)
 }
 
-func cloneHubFromContext(ctx context.Context) *sentry.Hub {
-	hub := sentry.GetHubFromContext(ctx)
-	if hub == nil {
-		hub = sentry.CurrentHub()
-	}
-	return hub.Clone()
+// cloneCtx creates a new background context for async work, with a cloned
+// sentry scope attached on it.
+func cloneCtx(ctx context.Context) context.Context {
+	_, scope := sentry.WithIsolationScope(ctx)
+	return sentry.ContextWithScope(context.Background(), scope)
 }
 
 func DefaultHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
@@ -119,9 +118,8 @@ func (h *Handler) EventsHandler(w http.ResponseWriter, r *http.Request, _ httpro
 			switch ev.ChannelType {
 			case "im":
 				// Handle direct messages to the bot separately
-				hub := cloneHubFromContext(ctx)
-				go func() {
-					ctx := sentry.SetHubOnContext(context.Background(), hub)
+				ctx = cloneCtx(ctx)
+				go func(ctx context.Context) {
 
 					options := []sentry.SpanOption{
 						sentry.WithOpName("event.handler"),
@@ -148,11 +146,10 @@ func (h *Handler) EventsHandler(w http.ResponseWriter, r *http.Request, _ httpro
 
 					h.emitEventMetric(txn.Context(), "potal.event.forwarded", "direct_message")
 					txn.Status = sentry.SpanStatusOK
-				}()
+				}(ctx)
 			default:
-				hub := cloneHubFromContext(ctx)
-				go func() {
-					ctx := sentry.SetHubOnContext(context.Background(), hub)
+				ctx = cloneCtx(ctx)
+				go func(ctx context.Context) {
 
 					options := []sentry.SpanOption{
 						sentry.WithOpName("event.handler"),
@@ -179,12 +176,11 @@ func (h *Handler) EventsHandler(w http.ResponseWriter, r *http.Request, _ httpro
 
 					h.emitEventMetric(txn.Context(), "potal.event.forwarded", "message")
 					txn.Status = sentry.SpanStatusOK
-				}()
+				}(ctx)
 			}
 		case *slackevents.ReactionAddedEvent:
-			hub := cloneHubFromContext(ctx)
-			go func() {
-				ctx := sentry.SetHubOnContext(context.Background(), hub)
+			ctx = cloneCtx(ctx)
+			go func(ctx context.Context) {
 
 				options := []sentry.SpanOption{
 					sentry.WithOpName("event.handler"),
@@ -212,11 +208,10 @@ func (h *Handler) EventsHandler(w http.ResponseWriter, r *http.Request, _ httpro
 
 				h.emitEventMetric(txn.Context(), "potal.event.forwarded", "reaction_added")
 				txn.Status = sentry.SpanStatusOK
-			}()
+			}(ctx)
 		case *slackevents.ReactionRemovedEvent:
-			hub := cloneHubFromContext(ctx)
-			go func() {
-				ctx := sentry.SetHubOnContext(context.Background(), hub)
+			ctx = cloneCtx(ctx)
+			go func(ctx context.Context) {
 
 				options := []sentry.SpanOption{
 					sentry.WithOpName("event.handler"),
@@ -244,11 +239,10 @@ func (h *Handler) EventsHandler(w http.ResponseWriter, r *http.Request, _ httpro
 
 				h.emitEventMetric(txn.Context(), "potal.event.forwarded", "reaction_removed")
 				txn.Status = sentry.SpanStatusOK
-			}()
+			}(ctx)
 		case *slackevents.AppMentionEvent:
-			hub := cloneHubFromContext(ctx)
-			go func() {
-				ctx := sentry.SetHubOnContext(context.Background(), hub)
+			ctx = cloneCtx(ctx)
+			go func(ctx context.Context) {
 
 				options := []sentry.SpanOption{
 					sentry.WithOpName("event.handler"),
@@ -276,12 +270,10 @@ func (h *Handler) EventsHandler(w http.ResponseWriter, r *http.Request, _ httpro
 
 				h.emitEventMetric(txn.Context(), "potal.event.forwarded", "app_mention")
 				txn.Status = sentry.SpanStatusOK
-			}()
+			}(ctx)
 		case *slackevents.AppHomeOpenedEvent:
-			go event.ProcessAppHomeOpenedEvent(r.Context(), ev)
-			hub := cloneHubFromContext(ctx)
-			go func() {
-				ctx := sentry.SetHubOnContext(context.Background(), hub)
+			ctx = cloneCtx(ctx)
+			go func(ctx context.Context) {
 
 				options := []sentry.SpanOption{
 					sentry.WithOpName("event.handler"),
@@ -309,12 +301,10 @@ func (h *Handler) EventsHandler(w http.ResponseWriter, r *http.Request, _ httpro
 
 				h.emitEventMetric(txn.Context(), "potal.event.forwarded", "app_home_opened")
 				txn.Status = sentry.SpanStatusOK
-			}()
+			}(ctx)
 		case *slackevents.LinkSharedEvent:
-			go event.ProcessLinkSharedEvent(r.Context(), ev)
-			hub := cloneHubFromContext(ctx)
-			go func() {
-				ctx := sentry.SetHubOnContext(context.Background(), hub)
+			ctx = cloneCtx(ctx)
+			go func(ctx context.Context) {
 
 				options := []sentry.SpanOption{
 					sentry.WithOpName("event.handler"),
@@ -341,7 +331,7 @@ func (h *Handler) EventsHandler(w http.ResponseWriter, r *http.Request, _ httpro
 
 				h.emitEventMetric(txn.Context(), "potal.event.forwarded", "link_shared")
 				txn.Status = sentry.SpanStatusOK
-			}()
+			}(ctx)
 		default:
 			slog.WarnContext(ctx, "unhandled callback event type", "type", innerEvent.Type)
 		}
@@ -375,9 +365,8 @@ func (h *Handler) SlashHandler(w http.ResponseWriter, r *http.Request, _ httprou
 			return
 		}
 	case "/gibopinion":
-		hub := cloneHubFromContext(ctx)
-		go func() {
-			ctx := sentry.SetHubOnContext(context.Background(), hub)
+		ctx = cloneCtx(ctx)
+		go func(ctx context.Context) {
 
 			options := []sentry.SpanOption{
 				sentry.WithOpName("command.handler"),
@@ -405,7 +394,7 @@ func (h *Handler) SlashHandler(w http.ResponseWriter, r *http.Request, _ httprou
 
 			h.emitEventMetric(txn.Context(), "potal.event.forwarded", "slash_command")
 			txn.Status = sentry.SpanStatusOK
-		}()
+		}(ctx)
 	default:
 		slog.WarnContext(ctx, "unknown slash command", "command", s.Command)
 		transaction.Status = sentry.SpanStatusInvalidArgument
@@ -434,9 +423,8 @@ func (h *Handler) InteractionsHandler(w http.ResponseWriter, r *http.Request, _ 
 
 	switch payload.Type {
 	case slack.InteractionTypeBlockActions:
-		hub := cloneHubFromContext(ctx)
-		go func() {
-			ctx := sentry.SetHubOnContext(context.Background(), hub)
+		ctx = cloneCtx(ctx)
+		go func(ctx context.Context) {
 
 			options := []sentry.SpanOption{
 				sentry.WithOpName("interaction.handler"),
@@ -464,11 +452,10 @@ func (h *Handler) InteractionsHandler(w http.ResponseWriter, r *http.Request, _ 
 
 			h.emitEventMetric(txn.Context(), "potal.event.forwarded", "interaction_callback")
 			txn.Status = sentry.SpanStatusOK
-		}()
+		}(ctx)
 	case slack.InteractionTypeViewSubmission:
-		hub := cloneHubFromContext(ctx)
-		go func() {
-			ctx := sentry.SetHubOnContext(context.Background(), hub)
+		ctx = cloneCtx(ctx)
+		go func(ctx context.Context) {
 
 			options := []sentry.SpanOption{
 				sentry.WithOpName("interaction.handler"),
@@ -496,7 +483,7 @@ func (h *Handler) InteractionsHandler(w http.ResponseWriter, r *http.Request, _ 
 
 			h.emitEventMetric(txn.Context(), "potal.event.forwarded", "view_submission")
 			txn.Status = sentry.SpanStatusOK
-		}()
+		}(ctx)
 	default:
 		slog.WarnContext(ctx, "unknown interaction type", "type", payload.Type)
 		transaction.Status = sentry.SpanStatusInvalidArgument

--- a/potal/internal/dieterhttp/client.go
+++ b/potal/internal/dieterhttp/client.go
@@ -28,18 +28,16 @@ func NewClient(meter sentry.Meter) *Client {
 func (c *Client) SendRequest(ctx context.Context, e event.PotalEvent) error {
 	url := os.Getenv("DIETER_URL")
 
-	hub := sentry.GetHubFromContext(ctx)
-
 	body, jsonErr := json.Marshal(e)
 	if jsonErr != nil {
-		hub.CaptureException(jsonErr)
+		sentry.CaptureException(ctx, jsonErr)
 		slog.ErrorContext(ctx, "failed to marshal event for dieter", "error", jsonErr)
 		return jsonErr
 	}
 
 	r, newReqErr := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(body))
 	if newReqErr != nil {
-		hub.CaptureException(newReqErr)
+		sentry.CaptureException(ctx, newReqErr)
 		slog.ErrorContext(ctx, "failed to create Dieter API request", "error", newReqErr)
 		return newReqErr
 	}
@@ -55,7 +53,7 @@ func (c *Client) SendRequest(ctx context.Context, e event.PotalEvent) error {
 
 	res, reqErr := client.Do(r)
 	if reqErr != nil {
-		hub.CaptureException(reqErr)
+		sentry.CaptureException(ctx, reqErr)
 		slog.ErrorContext(ctx, "Dieter API request failed", "error", reqErr)
 		return reqErr
 	}
@@ -77,10 +75,10 @@ func (c *Client) SendRequest(ctx context.Context, e event.PotalEvent) error {
 	msg := fmt.Sprintf("Dieter API: Got %s response", res.Status)
 	slog.ErrorContext(ctx, "Dieter API error response", "status", res.Status, "status_code", res.StatusCode)
 
-	hub.ConfigureScope(func(scope *sentry.Scope) {
+	sentry.WithScopeContext(ctx, func(ctx context.Context, scope *sentry.Scope) {
 		scope.SetLevel(sentry.LevelFatal)
+		sentry.CaptureMessage(ctx, msg)
 	})
-	hub.CaptureMessage(msg)
 
 	return fmt.Errorf("%s", msg)
 }

--- a/potal/internal/event/apphomeopened.go
+++ b/potal/internal/event/apphomeopened.go
@@ -20,7 +20,7 @@ func (e AppHomeOpenedEvent) isValid() bool {
 }
 
 func ProcessAppHomeOpenedEvent(ctx context.Context, e *slackevents.AppHomeOpenedEvent) *AppHomeOpenedEvent {
-	hub := sentry.GetHubFromContext(ctx)
+	scope := sentry.ScopeFromContext(ctx)
 	txn := sentry.TransactionFromContext(ctx)
 
 	span := txn.StartChild("event.process", sentry.WithDescription("Process AppHomeOpened Event"))
@@ -39,8 +39,8 @@ func ProcessAppHomeOpenedEvent(ctx context.Context, e *slackevents.AppHomeOpened
 	}
 	span.Status = sentry.SpanStatusOK
 
-	hub.Scope().SetContext("event", sentry.Context{"data": appHomeOpenedEvent})
-	hub.Scope().SetTag("event_type", appHomeOpened.String())
+	scope.SetContext("event", sentry.Context{"data": appHomeOpenedEvent})
+	scope.SetTag("event_type", appHomeOpened.String())
 
 	return &appHomeOpenedEvent
 }

--- a/potal/internal/event/appmention.go
+++ b/potal/internal/event/appmention.go
@@ -25,7 +25,7 @@ func (e AppMentionEvent) isValid() bool {
 }
 
 func ProcessAppMentionEvent(ctx context.Context, e *slackevents.AppMentionEvent) *AppMentionEvent {
-	hub := sentry.GetHubFromContext(ctx)
+	scope := sentry.ScopeFromContext(ctx)
 	txn := sentry.TransactionFromContext(ctx)
 
 	span := txn.StartChild("event.process", sentry.WithDescription("Process AppMention Event"))
@@ -48,8 +48,8 @@ func ProcessAppMentionEvent(ctx context.Context, e *slackevents.AppMentionEvent)
 	}
 	span.Status = sentry.SpanStatusOK
 
-	hub.Scope().SetContext("event", sentry.Context{"data": appMentionEvent})
-	hub.Scope().SetTag("event_type", appMention.String())
+	scope.SetContext("event", sentry.Context{"data": appMentionEvent})
+	scope.SetTag("event_type", appMention.String())
 
 	return &appMentionEvent
 }

--- a/potal/internal/event/directmessage.go
+++ b/potal/internal/event/directmessage.go
@@ -24,7 +24,7 @@ func (e DirectEvent) isValid() bool {
 }
 
 func ProcessDirectMessageEvent(ctx context.Context, e *slackevents.MessageEvent) *DirectEvent {
-	hub := sentry.GetHubFromContext(ctx)
+	scope := sentry.ScopeFromContext(ctx)
 	txn := sentry.TransactionFromContext(ctx)
 
 	span := txn.StartChild("event.process", sentry.WithDescription("Process Direct Message Event"))
@@ -46,8 +46,8 @@ func ProcessDirectMessageEvent(ctx context.Context, e *slackevents.MessageEvent)
 	}
 	span.Status = sentry.SpanStatusOK
 
-	hub.Scope().SetContext("event", sentry.Context{"data": directMessageEvent})
-	hub.Scope().SetTag("event_type", directMessage.String())
+	scope.SetContext("event", sentry.Context{"data": directMessageEvent})
+	scope.SetTag("event_type", directMessage.String())
 
 	return &directMessageEvent
 }

--- a/potal/internal/event/interactioncallback.go
+++ b/potal/internal/event/interactioncallback.go
@@ -23,7 +23,7 @@ func (e InteractionCallbackEvent) isValid() bool {
 }
 
 func ProcessInteractionCallbackEvent(ctx context.Context, e slack.InteractionCallback) *InteractionCallbackEvent {
-	hub := sentry.GetHubFromContext(ctx)
+	scope := sentry.ScopeFromContext(ctx)
 	txn := sentry.TransactionFromContext(ctx)
 
 	span := txn.StartChild("event.process", sentry.WithDescription("Process InteractionCallback Event"))
@@ -54,8 +54,8 @@ func ProcessInteractionCallbackEvent(ctx context.Context, e slack.InteractionCal
 	}
 	span.Status = sentry.SpanStatusOK
 
-	hub.Scope().SetContext("event", sentry.Context{"data": interactionEvent})
-	hub.Scope().SetTag("event_type", interactionCallback.String())
+	scope.SetContext("event", sentry.Context{"data": interactionEvent})
+	scope.SetTag("event_type", interactionCallback.String())
 
 	return &interactionEvent
 }

--- a/potal/internal/event/linkshared.go
+++ b/potal/internal/event/linkshared.go
@@ -30,7 +30,7 @@ func (e LinkSharedEvent) isValid() bool {
 }
 
 func ProcessLinkSharedEvent(ctx context.Context, e *slackevents.LinkSharedEvent) *LinkSharedEvent {
-	hub := sentry.GetHubFromContext(ctx)
+	scope := sentry.ScopeFromContext(ctx)
 	txn := sentry.TransactionFromContext(ctx)
 
 	span := txn.StartChild("event.process", sentry.WithDescription("Process LinkShared Event"))
@@ -61,8 +61,8 @@ func ProcessLinkSharedEvent(ctx context.Context, e *slackevents.LinkSharedEvent)
 	}
 	span.Status = sentry.SpanStatusOK
 
-	hub.Scope().SetContext("event", sentry.Context{"data": linkSharedEvent})
-	hub.Scope().SetTag("event_type", linkShared.String())
+	scope.SetContext("event", sentry.Context{"data": linkSharedEvent})
+	scope.SetTag("event_type", linkShared.String())
 
 	return &linkSharedEvent
 }

--- a/potal/internal/event/message.go
+++ b/potal/internal/event/message.go
@@ -36,7 +36,7 @@ func (e MessageEvent) isValid() bool {
 }
 
 func ProcessMessageEvent(ctx context.Context, e *slackevents.MessageEvent, sc *slack.Client) *MessageEvent {
-	hub := sentry.GetHubFromContext(ctx)
+	scope := sentry.ScopeFromContext(ctx)
 	txn := sentry.TransactionFromContext(ctx)
 
 	span := txn.StartChild("event.process", sentry.WithDescription("Process Message Event"))
@@ -71,7 +71,7 @@ func ProcessMessageEvent(ctx context.Context, e *slackevents.MessageEvent, sc *s
 	})
 	if err != nil {
 		permalinkSpan.Status = sentry.SpanStatusInternalError
-		hub.CaptureException(err)
+		sentry.CaptureException(ctx, err)
 		slog.ErrorContext(ctx, "failed to get permalink", "error", err, "channel", e.Channel)
 	} else {
 		permalinkSpan.Status = sentry.SpanStatusOK
@@ -81,8 +81,8 @@ func ProcessMessageEvent(ctx context.Context, e *slackevents.MessageEvent, sc *s
 	messageEvent.Permalink = permalink
 	messageEvent.Text = utils.ScrubText(messageEvent.Text)
 
-	hub.Scope().SetContext("event", sentry.Context{"data": messageEvent})
-	hub.Scope().SetTag("event_type", message.String())
+	scope.SetContext("event", sentry.Context{"data": messageEvent})
+	scope.SetTag("event_type", message.String())
 
 	return &messageEvent
 }

--- a/potal/internal/event/reactionadded.go
+++ b/potal/internal/event/reactionadded.go
@@ -34,7 +34,7 @@ func (e ReactionAddedEvent) isValid() bool {
 }
 
 func ProcessReactionEvent(ctx context.Context, e *slackevents.ReactionAddedEvent, sc *slack.Client) *ReactionAddedEvent {
-	hub := sentry.GetHubFromContext(ctx)
+	scope := sentry.ScopeFromContext(ctx)
 	txn := sentry.TransactionFromContext(ctx)
 
 	span := txn.StartChild("event.process", sentry.WithDescription("Process ReactionAdded Event"))
@@ -47,7 +47,7 @@ func ProcessReactionEvent(ctx context.Context, e *slackevents.ReactionAddedEvent
 	user, err := sc.GetUserInfo(e.User)
 	if err != nil {
 		userSpan.Status = sentry.SpanStatusInternalError
-		hub.CaptureException(err)
+		sentry.CaptureException(ctx, err)
 		slog.ErrorContext(ctx, "failed to get user", "error", err, "user", e.User)
 		return nil
 	} else {
@@ -76,7 +76,7 @@ func ProcessReactionEvent(ctx context.Context, e *slackevents.ReactionAddedEvent
 	if err != nil {
 		conversationsSpan.Status = sentry.SpanStatusInternalError
 		span.Status = sentry.SpanStatusInternalError
-		hub.CaptureException(err)
+		sentry.CaptureException(ctx, err)
 		slog.ErrorContext(ctx, "failed to get conversation replies", "error", err, "channel", e.Item.Channel)
 		return nil
 	}
@@ -109,7 +109,7 @@ func ProcessReactionEvent(ctx context.Context, e *slackevents.ReactionAddedEvent
 	})
 	if err != nil {
 		permaLinkSpan.Status = sentry.SpanStatusInternalError
-		hub.CaptureException(err)
+		sentry.CaptureException(ctx, err)
 		slog.ErrorContext(ctx, "failed to get permalink", "error", err, "channel", e.Item.Channel)
 	} else {
 		permaLinkSpan.Status = sentry.SpanStatusOK
@@ -132,8 +132,8 @@ func ProcessReactionEvent(ctx context.Context, e *slackevents.ReactionAddedEvent
 
 	span.Status = sentry.SpanStatusOK
 
-	hub.Scope().SetContext("event", sentry.Context{"data": reactionEvent})
-	hub.Scope().SetTag("event_type", reactionAdded.String())
+	scope.SetContext("event", sentry.Context{"data": reactionEvent})
+	scope.SetTag("event_type", reactionAdded.String())
 
 	return &reactionEvent
 }

--- a/potal/internal/event/reactionremoved.go
+++ b/potal/internal/event/reactionremoved.go
@@ -25,7 +25,7 @@ func (e ReactionRemovedEvent) isValid() bool {
 }
 
 func ProcessReactionRemovedEvent(ctx context.Context, e *slackevents.ReactionRemovedEvent, sc *slack.Client) *ReactionRemovedEvent {
-	hub := sentry.GetHubFromContext(ctx)
+	scope := sentry.ScopeFromContext(ctx)
 	txn := sentry.TransactionFromContext(ctx)
 
 	span := txn.StartChild("event.process", sentry.WithDescription("Process ReactionRemoved Event"))
@@ -37,7 +37,7 @@ func ProcessReactionRemovedEvent(ctx context.Context, e *slackevents.ReactionRem
 	user, err := sc.GetUserInfo(e.User)
 	if err != nil {
 		userSpan.Status = sentry.SpanStatusInternalError
-		hub.CaptureException(err)
+		sentry.CaptureException(ctx, err)
 		slog.ErrorContext(ctx, "failed to get user", "error", err, "user", e.User)
 		return nil
 	} else {
@@ -65,8 +65,8 @@ func ProcessReactionRemovedEvent(ctx context.Context, e *slackevents.ReactionRem
 
 	span.Status = sentry.SpanStatusOK
 
-	hub.Scope().SetContext("event", sentry.Context{"data": removedEvent})
-	hub.Scope().SetTag("event_type", reactionRemoved.String())
+	scope.SetContext("event", sentry.Context{"data": removedEvent})
+	scope.SetTag("event_type", reactionRemoved.String())
 
 	return &removedEvent
 }

--- a/potal/internal/event/slashcommand.go
+++ b/potal/internal/event/slashcommand.go
@@ -21,7 +21,7 @@ func (e SlashCommandEvent) isValid() bool {
 }
 
 func ProcessSlashCommand(ctx context.Context, e slack.SlashCommand) *SlashCommandEvent {
-	hub := sentry.GetHubFromContext(ctx)
+	scope := sentry.ScopeFromContext(ctx)
 	txn := sentry.TransactionFromContext(ctx)
 
 	span := txn.StartChild("event.process", sentry.WithDescription("Process SlashCommand Event"))
@@ -42,8 +42,8 @@ func ProcessSlashCommand(ctx context.Context, e slack.SlashCommand) *SlashComman
 	}
 	span.Status = sentry.SpanStatusOK
 
-	hub.Scope().SetContext("event", sentry.Context{"data": slashCommandEvent})
-	hub.Scope().SetTag("event_type", slashCommand.String())
+	scope.SetContext("event", sentry.Context{"data": slashCommandEvent})
+	scope.SetTag("event_type", slashCommand.String())
 
 	return &slashCommandEvent
 }

--- a/potal/internal/event/viewsubmission.go
+++ b/potal/internal/event/viewsubmission.go
@@ -20,7 +20,7 @@ func (e ViewSubmissionEvent) isValid() bool {
 }
 
 func ProcessViewSubmissionEvent(ctx context.Context, e slack.InteractionCallback) *ViewSubmissionEvent {
-	hub := sentry.GetHubFromContext(ctx)
+	scope := sentry.ScopeFromContext(ctx)
 	txn := sentry.TransactionFromContext(ctx)
 
 	span := txn.StartChild("event.process", sentry.WithDescription("Process ViewSubmission Event"))
@@ -54,8 +54,8 @@ func ProcessViewSubmissionEvent(ctx context.Context, e slack.InteractionCallback
 	}
 	span.Status = sentry.SpanStatusOK
 
-	hub.Scope().SetContext("event", sentry.Context{"data": viewSubmissionEvent})
-	hub.Scope().SetTag("event_type", viewSubmission.String())
+	scope.SetContext("event", sentry.Context{"data": viewSubmissionEvent})
+	scope.SetTag("event_type", viewSubmission.String())
 
 	return &viewSubmissionEvent
 }

--- a/potal/internal/potalhttp/client.go
+++ b/potal/internal/potalhttp/client.go
@@ -28,18 +28,16 @@ func NewClient(meter sentry.Meter) *Client {
 func (c *Client) SendRequest(ctx context.Context, e event.PotalEvent) error {
 	url := os.Getenv("POTAL_URL")
 
-	hub := sentry.GetHubFromContext(ctx)
-
 	body, jsonErr := json.Marshal(e)
 	if jsonErr != nil {
-		hub.CaptureException(jsonErr)
+		sentry.CaptureException(ctx, jsonErr)
 		slog.ErrorContext(ctx, "failed to marshal event", "error", jsonErr)
 		return jsonErr
 	}
 
 	r, newReqErr := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(body))
 	if newReqErr != nil {
-		hub.CaptureException(newReqErr)
+		sentry.CaptureException(ctx, newReqErr)
 		slog.ErrorContext(ctx, "failed to create API request", "error", newReqErr)
 		return newReqErr
 	}
@@ -55,7 +53,7 @@ func (c *Client) SendRequest(ctx context.Context, e event.PotalEvent) error {
 
 	res, reqErr := client.Do(r)
 	if reqErr != nil {
-		hub.CaptureException(reqErr)
+		sentry.CaptureException(ctx, reqErr)
 		slog.ErrorContext(ctx, "API request failed", "error", reqErr)
 		return reqErr
 	}
@@ -77,10 +75,10 @@ func (c *Client) SendRequest(ctx context.Context, e event.PotalEvent) error {
 	msg := fmt.Sprintf("GibPotato API: Got %s response", res.Status)
 	slog.ErrorContext(ctx, "API error response", "status", res.Status, "status_code", res.StatusCode)
 
-	hub.ConfigureScope(func(scope *sentry.Scope) {
+	sentry.WithScopeContext(ctx, func(ctx context.Context, scope *sentry.Scope) {
 		scope.SetLevel(sentry.LevelFatal)
+		sentry.CaptureMessage(ctx, msg)
 	})
-	hub.CaptureMessage(msg)
 
 	return fmt.Errorf("%s", msg)
 }

--- a/potal/main.go
+++ b/potal/main.go
@@ -71,7 +71,7 @@ func main() {
 	slog.Info("server starting", "port", 3000)
 	httpErr := http.ListenAndServe(":3000", sentryHandler.Handle(router))
 	if httpErr != nil {
-		sentry.CaptureException(httpErr)
+		sentry.CaptureException(context.Background(), httpErr)
 		slog.Error("server failed", "error", httpErr)
 		os.Exit(1)
 	}


### PR DESCRIPTION
This updates potal to use and dogfood the new sentry-go scopes migration. The pinned hash for testing originates from https://github.com/getsentry/sentry-go/pull/1407.