### PR TITLE
chore(deps): Bump Sentry JS SDK to 11.0.0-beta.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,8 @@
             "name": "gib-potato",
             "dependencies": {
                 "@laravel/multiplex": "^0.4.3",
-                "@sentry/bundler-plugins": "^11.0.0-alpha.2",
-                "@sentry/vue": "^11.0.0-alpha.2",
+                "@sentry/bundler-plugins": "^11.0.0-beta.0",
+                "@sentry/vue": "^11.0.0-beta.0",
                 "@tailwindcss/vite": "^4.3.3",
                 "axios": "^1.20.0",
                 "vue": "^3.5.42",
@@ -1360,30 +1360,30 @@
             "license": "MIT"
         },
         "node_modules/@sentry/browser": {
-            "version": "11.0.0-alpha.2",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/browser/-/browser-11.0.0-alpha.2.tgz",
-            "integrity": "sha512-uRSfYolWGt4bBAq41wTp48ejK/wvyXW/QYQ8/vvlB2o1HgNcdaYZhPjHvkL4uDa19z+/dfEldSFRh0ZZP/w1qA==",
+            "version": "11.0.0-beta.0",
+            "resolved": "https://sfw.security.sentry.io/npm/@sentry/browser/-/browser-11.0.0-beta.0.tgz",
+            "integrity": "sha512-1GD5xKzQNSxqeHugPyb0XwL+BXAkPFy1Y+Q6tQxjwqLBC8VT8AV5zU3HcBGOU4DrV3zHMPB3V4siL/Bk1/SwXA==",
             "license": "MIT",
             "dependencies": {
-                "@sentry/browser-utils": "11.0.0-alpha.2",
+                "@sentry/browser-utils": "11.0.0-beta.0",
                 "@sentry/conventions": "^0.20.0",
-                "@sentry/core": "11.0.0-alpha.2",
-                "@sentry/feedback": "11.0.0-alpha.2",
-                "@sentry/replay": "11.0.0-alpha.2",
-                "@sentry/replay-canvas": "11.0.0-alpha.2"
+                "@sentry/core": "11.0.0-beta.0",
+                "@sentry/feedback": "11.0.0-beta.0",
+                "@sentry/replay": "11.0.0-beta.0",
+                "@sentry/replay-canvas": "11.0.0-beta.0"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.12.0 <23.0.0 || >=23.2.0"
             }
         },
         "node_modules/@sentry/browser-utils": {
-            "version": "11.0.0-alpha.2",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/browser-utils/-/browser-utils-11.0.0-alpha.2.tgz",
-            "integrity": "sha512-6jr3V9hqAsAJ7WgOd0TtJtmOgI9CCfv1utfW+2D9NxqcGy68fFbXeDucCSt8z0hFrEJaOSCejhvQva297P8xMA==",
+            "version": "11.0.0-beta.0",
+            "resolved": "https://sfw.security.sentry.io/npm/@sentry/browser-utils/-/browser-utils-11.0.0-beta.0.tgz",
+            "integrity": "sha512-fUYt/j5ZYdsmPqiTZKraz/nb7HRnwD3ZKAdXnsunRstZ31E6RCIonRvbEtJ7TcqerWOCMQgXf4BgOzgD3+lhRw==",
             "license": "MIT",
             "dependencies": {
                 "@sentry/conventions": "^0.20.0",
-                "@sentry/core": "11.0.0-alpha.2",
+                "@sentry/core": "11.0.0-beta.0",
                 "web-vitals": "^6.0.1"
             },
             "engines": {
@@ -1391,13 +1391,13 @@
             }
         },
         "node_modules/@sentry/bundler-plugins": {
-            "version": "11.0.0-alpha.2",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/bundler-plugins/-/bundler-plugins-11.0.0-alpha.2.tgz",
-            "integrity": "sha512-cWTtt94lsNmZTGo8Rr0IDilfc4wuuaDnEvhoZqvuo2RJixMtwr3Erq9S1nbiX4jnP2fcLNnZm8nc/R4BbLIHrg==",
+            "version": "11.0.0-beta.0",
+            "resolved": "https://sfw.security.sentry.io/npm/@sentry/bundler-plugins/-/bundler-plugins-11.0.0-beta.0.tgz",
+            "integrity": "sha512-ry377xZy4ChLyz6VTEpzbF40rZaEXFHfieLAP3mdWQRFBYHaxjAxVBNqOx0Tl+TbHhEIq4v9SIXVNdxDjuj1pw==",
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.18.5",
-                "@sentry/core": "11.0.0-alpha.2",
+                "@sentry/core": "11.0.0-beta.0",
                 "dotenv": "^17.4.2",
                 "find-up": "^5.0.0",
                 "glob": "^13.0.6",
@@ -1431,9 +1431,9 @@
             }
         },
         "node_modules/@sentry/core": {
-            "version": "11.0.0-alpha.2",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/core/-/core-11.0.0-alpha.2.tgz",
-            "integrity": "sha512-GvqlS+z2UxCy92nrH0PMYn/Xw5Tw40VNGkJ85G/C7S55O/NO3c8vU+oJG9/exCKgs/N+u7fSKYgPubuvaArkLQ==",
+            "version": "11.0.0-beta.0",
+            "resolved": "https://sfw.security.sentry.io/npm/@sentry/core/-/core-11.0.0-beta.0.tgz",
+            "integrity": "sha512-ymS/r17xHxMJjXRO75Q2ecQImg7BWwsZGVjov8aCVrCkga0ab/P0LiSfKGJo4lBTt9+ZncdxVv7PunQ8PhqKYA==",
             "license": "MIT",
             "dependencies": {
                 "@sentry/conventions": "^0.20.0"
@@ -1443,52 +1443,52 @@
             }
         },
         "node_modules/@sentry/feedback": {
-            "version": "11.0.0-alpha.2",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/feedback/-/feedback-11.0.0-alpha.2.tgz",
-            "integrity": "sha512-sbEoZ1wIgYBEg1ecDwBLy68djJxBM9bg4zVGR+2nrQ9TID8wDn08kw0TQiVzwg2EO6PGVvjj1ukviJRMiuS6qA==",
+            "version": "11.0.0-beta.0",
+            "resolved": "https://sfw.security.sentry.io/npm/@sentry/feedback/-/feedback-11.0.0-beta.0.tgz",
+            "integrity": "sha512-P2hORL7E+xndOjA0S/h7pPPNh1LsBXZZ0e94+QavBMWB7foIU0XeP/RBx3oo1WRMIQml4qop7LQ9RoXJGbaawQ==",
             "license": "MIT",
             "dependencies": {
-                "@sentry/core": "11.0.0-alpha.2"
+                "@sentry/core": "11.0.0-beta.0"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.12.0 <23.0.0 || >=23.2.0"
             }
         },
         "node_modules/@sentry/replay": {
-            "version": "11.0.0-alpha.2",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/replay/-/replay-11.0.0-alpha.2.tgz",
-            "integrity": "sha512-djxcu+7VSnFcGUaxH+McUyrTAo2JiKf0vwoFWF9ACJiYN3craSIWUlc0jopeoL0xD40piNBAQltbmh0WDf1Dwg==",
+            "version": "11.0.0-beta.0",
+            "resolved": "https://sfw.security.sentry.io/npm/@sentry/replay/-/replay-11.0.0-beta.0.tgz",
+            "integrity": "sha512-Tv+FhQWQo/xh8MH/Nxpxz6FxRlF8lX4yq8QMGt2u5QHqCJqce3l9xWaa+jp7R5JBvKzQFxn3mneq2HXqD+TbBg==",
             "license": "MIT",
             "dependencies": {
-                "@sentry/browser-utils": "11.0.0-alpha.2",
-                "@sentry/core": "11.0.0-alpha.2"
+                "@sentry/browser-utils": "11.0.0-beta.0",
+                "@sentry/core": "11.0.0-beta.0"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.12.0 <23.0.0 || >=23.2.0"
             }
         },
         "node_modules/@sentry/replay-canvas": {
-            "version": "11.0.0-alpha.2",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/replay-canvas/-/replay-canvas-11.0.0-alpha.2.tgz",
-            "integrity": "sha512-Pui732KXikj5L1EJd8hsQ4GbhKhNaZ0aHSEdlNJRMQMYCIApvJCY9CM/j86NrEt8bY3ShLs46r8T1iyT4NRJfw==",
+            "version": "11.0.0-beta.0",
+            "resolved": "https://sfw.security.sentry.io/npm/@sentry/replay-canvas/-/replay-canvas-11.0.0-beta.0.tgz",
+            "integrity": "sha512-fiLoYRl1+XWwmObJXtcMJXVqFlpMZpXN+5O0FRMN1rE1dLU5VeiDieXZtx6Mkp6BVXEDhefVKrsqEO9WOYmVyw==",
             "license": "MIT",
             "dependencies": {
-                "@sentry/core": "11.0.0-alpha.2",
-                "@sentry/replay": "11.0.0-alpha.2"
+                "@sentry/core": "11.0.0-beta.0",
+                "@sentry/replay": "11.0.0-beta.0"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.12.0 <23.0.0 || >=23.2.0"
             }
         },
         "node_modules/@sentry/vue": {
-            "version": "11.0.0-alpha.2",
-            "resolved": "https://sfw.security.sentry.io/npm/@sentry/vue/-/vue-11.0.0-alpha.2.tgz",
-            "integrity": "sha512-F+HgkinrN5Yjck+ZZz7bt1EkpcC6iMS5PHNIzYoMAn8jdFuoN5aEmKJWz2bqfwXNvKnIG02U3xJAJo4xmSr0dQ==",
+            "version": "11.0.0-beta.0",
+            "resolved": "https://sfw.security.sentry.io/npm/@sentry/vue/-/vue-11.0.0-beta.0.tgz",
+            "integrity": "sha512-FUyCyPOjQoKdlildq+sApkWUcDd2RfEtqrSEHB9rwcQx3uOZYHaSwkUTkJPxNQmu2ygDB3qz0PqT1NHa8g59zA==",
             "license": "MIT",
             "dependencies": {
-                "@sentry/browser": "11.0.0-alpha.2",
+                "@sentry/browser": "11.0.0-beta.0",
                 "@sentry/conventions": "^0.20.0",
-                "@sentry/core": "11.0.0-alpha.2"
+                "@sentry/core": "11.0.0-beta.0"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.12.0 <23.0.0 || >=23.2.0"

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     },
     "dependencies": {
         "@laravel/multiplex": "^0.4.3",
-        "@sentry/bundler-plugins": "^11.0.0-alpha.2",
-        "@sentry/vue": "^11.0.0-alpha.2",
+        "@sentry/bundler-plugins": "^11.0.0-beta.0",
+        "@sentry/vue": "^11.0.0-beta.0",
         "@tailwindcss/vite": "^4.3.3",
         "axios": "^1.20.0",
         "vue": "^3.5.42",


### PR DESCRIPTION
## What

Bumps `@sentry/vue` and `@sentry/bundler-plugins` to 11.0.0-beta.0.

## Why

Keep gib-potato on the latest v11 prerelease so we catch breaking changes before it goes stable.